### PR TITLE
Remove last printlns

### DIFF
--- a/src/parse/symbol/statement/if_block.rs
+++ b/src/parse/symbol/statement/if_block.rs
@@ -38,7 +38,7 @@ impl<T: Tokenizer> PrefixParser<Statement, T> for IfBlockParser {
                 return Err(ParseError::LazyString(error.to_string()))
             }
             let else_expr = try!(parser.expression(Precedence::Min));
-            println!("Parsed infix if false expr");
+            trace!("Parsed infix if false expr");
             let if_expr = IfExpression::new(token,
                                             Box::new(condition),
                                             Box::new(true_expr),

--- a/src/parse/verify/checker/symbol_checker.rs
+++ b/src/parse/verify/checker/symbol_checker.rs
@@ -66,7 +66,7 @@ impl ASTVisitor for SymbolTableChecker {
         }
     }
     fn check_assignment(&mut self, assign: &Assignment) {
-        println!("Checking assignment to {}", assign.lvalue.get_name());
+        trace!("Checking assignment to {}", assign.lvalue.get_name());
         if let Some(index) = self.table_builder.get(assign.lvalue.get_name()) {
             trace!("Found reference to {} at {:?}", assign.lvalue.get_name(), index);
             assign.lvalue.set_index(index.clone());


### PR DESCRIPTION
Replace the last couple of `println!`s used for debugging with `trace!`.

Closes #12. 