### PR TITLE
Functions!

### DIFF
--- a/src/compile/module_compiler.rs
+++ b/src/compile/module_compiler.rs
@@ -170,6 +170,7 @@ impl<M:ModuleProvider> ASTVisitor for ModuleCompiler<M> {
         }
     }
 
+    /*
     fn check_unit(&mut self, unit: &Unit) {
         trace!("Checking unit");
         let fn_ret_double = RealTypeRef::get_float().to_ref();
@@ -208,6 +209,7 @@ impl<M:ModuleProvider> ASTVisitor for ModuleCompiler<M> {
             .verify(LLVMVerifierFailureAction::LLVMPrintMessageAction)
             .unwrap();
     }
+    */
 
     fn check_if_expr(&mut self, if_expr: &IfExpression) {
         // Build conditional expr

--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -17,61 +17,13 @@ pub fn create_module_compiler(input: &'static str, name: &str, optimize: bool)
 #[test]
 fn compile_basic_programs() {
     let inputs = &[
-        "1",
-        "let a = 0 a",
-        "let a = 0 return a",
-        "let a = 0 a + 1",
-        "let mut a = 0 a + 1",
-
-        "let mut a = 0 \n\
-        let b = a + 1 \n\
-        a = a + b \n\
-        a = a + 1 \n\
-        a = a % 2 \n\
-        a = a * 2 \n\
-        return a",
-
-        /*"let mut b = 0
-        b += 1
-        do
-            let mut c = 0
-            c = c + 1
-            b *= c
-        return b",
-        "let a = 0 \n\
-        let b = if a => 1 else 2\n\
-        let c = b + 1 \n\
-        return c",*/
-
 r#"
-let mut a = 0
-if a < 1
-    let b = 0
-else if a > 1
-    let b = 1
-else
-    let b = 2
-return a"#,
-
-r#"if 0 > 1
-    let a = 0
-return 1"#,
-
-r#"if 1 > 0 => 1 else 0"#,
-
-r#"
-if 1 > 0
-    let x = 0
-    2
-else if 2 < 3
-    let y = 0
-    4
-//else if 1 + 2 > 4
-//    let x = 1
-//    5
-else
-    let x = 1
-    4"#
+fn fact(n)
+    if n == 0
+        0
+    else
+        1
+"#
     ];
 
     for (ix, input) in inputs.into_iter().enumerate() {

--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -15,17 +15,23 @@ pub fn create_module_compiler(input: &'static str, name: &str, optimize: bool)
 }
 
 #[test]
-fn compile_basic_programs() {
+fn compile_example() {
     let inputs = &[
 r#"
-fn fact(n)
-    if n == 0
-        0
+fn factHelper(n, acc)
+    if n <= 2
+        acc
     else
-        1
+        factHelper(n: n - 1, acc: acc * n)
+fn fact(n)
+    factHelper(n, acc: 1)
 "#
     ];
-
+    /*
+    ::env_logger::LogBuilder::new()
+        .parse("TRACE")
+        .init()
+        .unwrap();*/
     for (ix, input) in inputs.into_iter().enumerate() {
         trace!("Checking program {} - {:?}", ix, input);
         let name = format!("dump_basic_definitions_{}", ix);

--- a/src/lex/tests.rs
+++ b/src/lex/tests.rs
@@ -553,9 +553,37 @@ fn it_tokenizes_complex_input() {
     });
 }
 
-fn print_parses(input: &'static str) {
-    println!("Input: {}", input);
-    println!("-------------------");
+#[test]
+fn lex_example() {
+    let inputs = &[
+r#"
+fn foo args
+    block
+fn foo2 args
+    block
+"#,
+    ];
+
+    let format = |record: &::log::LogRecord| {
+        format!("[{} {}] {}",
+            &record.location().module_path()[12..],
+            record.location().line(), record.args())
+    };
+
+    ::env_logger::LogBuilder::new()
+        .parse("TRACE")
+        .format(format)
+        .init()
+        .unwrap();
+
+    for input in inputs {
+        log_parses(input);
+    }
+}
+
+fn log_parses(input: &'static str) {
+    trace!("Input: {}", input);
+    trace!("-------------------");
     let mut tokenizer = make_tokenizer(input);
     let mut tokens = Vec::new();
     let mut next = tokenizer.next();
@@ -564,7 +592,7 @@ fn print_parses(input: &'static str) {
         next = tokenizer.next();
     }
     for token in tokens {
-        println!("{} ({:?})", token.get_text(), token.get_type());
+        trace!("{} ({:?})", token.get_text(), token.get_type());
     }
-    println!("===================\n");
+    trace!("===================\n");
 }

--- a/src/lex/textiter.rs
+++ b/src/lex/textiter.rs
@@ -69,6 +69,7 @@ impl<T: Iterator<Item=char>> Iterator for PeekTextIter<T> {
             },
             None => {}
         }
+        trace!("> Next char {:?}", result);
         result
     }
 

--- a/src/lex/tokens.rs
+++ b/src/lex/tokens.rs
@@ -62,7 +62,8 @@ declare_tokens! {
         LeftParen: "("; Complete,
         RightParen: ")"; Complete,
         GitMarker: "<<<<<<<"; Complete,
-        InlineArrow: "=>"; Complete
+        InlineArrow: "=>"; Complete,
+        Arrow: "->"; Complete
     }
     symparts {
         "//"; CompletePrefix, // Comments hack, allows // and /// to be parsed.
@@ -78,6 +79,7 @@ declare_tokens! {
         Return: "return",
         Do: "do",
         If: "if",
-        Else: "else"
+        Else: "else",
+        Fn: "fn"
     }
 }

--- a/src/lex/tokens.rs
+++ b/src/lex/tokens.rs
@@ -63,7 +63,8 @@ declare_tokens! {
         RightParen: ")"; Complete,
         GitMarker: "<<<<<<<"; Complete,
         InlineArrow: "=>"; Complete,
-        Arrow: "->"; Complete
+        Arrow: "->"; Complete,
+        Comma: ","; Complete
     }
     symparts {
         "//"; CompletePrefix, // Comments hack, allows // and /// to be parsed.

--- a/src/lex/tokens.rs
+++ b/src/lex/tokens.rs
@@ -8,9 +8,9 @@ use lex::TokenizerSymbolRule::*;
 
 macro_rules! declare_tokens {
     (
-        symbols { $($sym_name:ident : $sym_val:expr; $sym_rule:expr),* }
-        symparts { $($part_val:expr; $part_rule:expr),* }
-        keywords { $($kw_name:ident : $kw_val:expr),* }
+        symbols { $($sym_name:ident : $sym_val:expr; $sym_rule:expr,)* }
+        symparts { $($part_val:expr; $part_rule:expr,)* }
+        keywords { $($kw_name:ident : $kw_val:expr,)* }
     ) => {
         $(#[allow(non_upper_case_globals, dead_code)]
         pub const $kw_name : CowStr = Cow::Borrowed($kw_val);)*
@@ -64,7 +64,8 @@ declare_tokens! {
         GitMarker: "<<<<<<<"; Complete,
         InlineArrow: "=>"; Complete,
         Arrow: "->"; Complete,
-        Comma: ","; Complete
+        Comma: ","; Complete,
+        Colon: ":"; Complete,
     }
     symparts {
         "//"; CompletePrefix, // Comments hack, allows // and /// to be parsed.
@@ -72,7 +73,7 @@ declare_tokens! {
         "<<<"; Partial,
         "<<<<"; Partial,
         "<<<<<"; Partial,
-        "!"; Partial
+        "!"; Partial,
     }
     keywords {
         Let: "let",
@@ -81,6 +82,6 @@ declare_tokens! {
         Do: "do",
         If: "if",
         Else: "else",
-        Fn: "fn"
+        Fn: "fn",
     }
 }

--- a/src/parse/ast/expression.rs
+++ b/src/parse/ast/expression.rs
@@ -20,7 +20,8 @@ pub enum Expression {
     UnaryOp(UnaryOperation),
     /// If expression
     IfExpression(IfExpression),
-
+    /// Invocation of a funciton with standard named arg setup.
+    FnCall(FnCall),
     // "Non-value expressions"
     // I _guess_ they could return `()`, but why?
 
@@ -215,5 +216,52 @@ impl IfExpression {
     }
     pub fn get_else(&self) -> &Expression {
         &self.else_expr
+    }
+}
+
+/// Represents invocation of a function
+#[derive(Debug, PartialEq, Clone)]
+pub struct FnCall {
+    lvalue: Identifier,
+    paren_token: Token,
+    args: Vec<CallArgument>
+}
+
+impl FnCall {
+    pub fn new(lvalue: Identifier, token: Token, args: Vec<CallArgument>) -> FnCall {
+        FnCall { lvalue: lvalue, paren_token: token, args: args }
+    }
+    pub fn get_name(&self) -> &Identifier {
+        &self.lvalue
+    }
+    pub fn get_token(&self) -> &Token {
+        &self.paren_token
+    }
+    pub fn get_args(&self) -> &[CallArgument] {
+        &self.args
+    }
+}
+
+/// Represents arguments given to call a function with
+#[derive(Debug, PartialEq, Clone)]
+pub struct CallArgument {
+    name: Identifier,
+    expr: Option<Expression>
+}
+impl CallArgument {
+    pub fn var_name(name: Identifier) -> CallArgument {
+        CallArgument { name: name, expr: None }
+    }
+    pub fn var_value(name: Identifier, expr: Expression) -> CallArgument {
+        CallArgument { name: name, expr: Some(expr) }
+    }
+    pub fn get_name(&self) -> &Identifier {
+        &self.name
+    }
+    pub fn has_value(&self) -> bool {
+        self.expr.is_some()
+    }
+    pub fn get_expr(&self) -> Option<&Expression> {
+        self.expr.as_ref()
     }
 }

--- a/src/parse/ast/expression.rs
+++ b/src/parse/ast/expression.rs
@@ -224,12 +224,22 @@ impl IfExpression {
 pub struct FnCall {
     lvalue: Identifier,
     paren_token: Token,
-    args: Vec<CallArgument>
+    args: FnCallArgs
 }
 
 impl FnCall {
-    pub fn new(lvalue: Identifier, token: Token, args: Vec<CallArgument>) -> FnCall {
+    pub fn new(lvalue: Identifier, token: Token, args: FnCallArgs) -> FnCall {
         FnCall { lvalue: lvalue, paren_token: token, args: args }
+    }
+    pub fn named(lvalue: Identifier, token: Token, args: Vec<CallArgument>) -> FnCall {
+        FnCall { lvalue: lvalue, paren_token: token, args: FnCallArgs::Arguments(args) }
+    }
+    pub fn single_expr(lvalue: Identifier, token: Token, arg: Expression) -> FnCall {
+        FnCall {
+            lvalue: lvalue,
+            paren_token: token,
+            args: FnCallArgs::SingleExpr(Box::new(arg))
+        }
     }
     pub fn get_name(&self) -> &Identifier {
         &self.lvalue
@@ -237,9 +247,17 @@ impl FnCall {
     pub fn get_token(&self) -> &Token {
         &self.paren_token
     }
-    pub fn get_args(&self) -> &[CallArgument] {
+    pub fn get_args(&self) -> &FnCallArgs {
         &self.args
     }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum FnCallArgs {
+    /// Function was called with a single expression
+    SingleExpr(Box<Expression>),
+    /// Function was called with a list of arguments
+    Arguments(Vec<CallArgument>)
 }
 
 /// Represents arguments given to call a function with

--- a/src/parse/ast/expression.rs
+++ b/src/parse/ast/expression.rs
@@ -244,6 +244,9 @@ impl FnCall {
     pub fn get_name(&self) -> &Identifier {
         &self.lvalue
     }
+    pub fn get_text(&self) -> &str {
+        self.get_name().get_name()
+    }
     pub fn get_token(&self) -> &Token {
         &self.paren_token
     }
@@ -258,6 +261,14 @@ pub enum FnCallArgs {
     SingleExpr(Box<Expression>),
     /// Function was called with a list of arguments
     Arguments(Vec<CallArgument>)
+}
+impl FnCallArgs {
+    pub fn len(&self) -> usize {
+        match *self {
+            FnCallArgs::SingleExpr(_) => 1,
+            FnCallArgs::Arguments(ref args) => args.len()
+        }
+    }
 }
 
 /// Represents arguments given to call a function with
@@ -275,6 +286,9 @@ impl CallArgument {
     }
     pub fn get_name(&self) -> &Identifier {
         &self.name
+    }
+    pub fn get_text(&self) -> &str {
+        self.name.get_name()
     }
     pub fn has_value(&self) -> bool {
         self.expr.is_some()

--- a/src/parse/ast/item.rs
+++ b/src/parse/ast/item.rs
@@ -4,7 +4,8 @@
 //! -- namely the imort item `use`, and declarations such as `class`,
 //! `enum`, `struct`.
 
-use parse::ast::Block;
+use lex::{Token};
+use parse::ast::{Identifier, Block};
 
 // This will expand greatly in the future, but for now it's a solid way
 // to have an "enty point" in the compiler (and allow nested blocks)
@@ -15,12 +16,58 @@ use parse::ast::Block;
 /// complete with lists of defined types, functions, etc.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Unit {
-    pub block: Block
+    items: Vec<Item>
+}
+
+/// Items exported from a protosnirk program
+#[derive(Debug, Clone, PartialEq)]
+pub enum Item {
+    FnDeclaration(FnDeclaration)
 }
 
 impl Unit {
     /// Create a new unit with the given block
-    pub fn new(block: Block) -> Unit {
-        Unit { block: block }
+    pub fn new(items: Vec<Item>) -> Unit {
+        Unit { items: items }
+    }
+    pub fn get_items(&self) -> &[Item] {
+        &self.items
+    }
+}
+
+/// Declaration of a function
+#[derive(Debug, Clone, PartialEq)]
+pub struct FnDeclaration {
+    fn_token: Token,
+    name: Identifier,
+    arg_list: Vec<Identifier>, // No types here yet :/
+    block: Block
+}
+impl FnDeclaration {
+    /// Create a new FnDeclaration
+    pub fn new(fn_token: Token, name: Identifier, arg_list: Vec<Identifier>, block: Block)
+               -> FnDeclaration {
+        FnDeclaration {
+            fn_token: fn_token,
+            name: name,
+            arg_list: arg_list,
+            block: block
+        }
+    }
+    /// Get the `fn` token
+    pub fn get_token(&self) -> &Token {
+        &self.fn_token
+    }
+    /// Get the name of the function
+    pub fn get_name(&self) -> &Identifier {
+        &self.name
+    }
+    /// Get the prototype of the function
+    pub fn get_args(&self) -> &Vec<Identifier> {
+        &self.arg_list
+    }
+    /// Get the block inside the function
+    pub fn get_block(&self) -> &Block {
+        &self.block
     }
 }

--- a/src/parse/ast_visitor.rs
+++ b/src/parse/ast_visitor.rs
@@ -11,7 +11,9 @@ use super::{ErrorCollector, VerifyError};
 /// Trait for expression checkers: visitors on the expression tree.
 pub trait ASTVisitor {
     fn check_unit(&mut self, unit: &Unit) {
-        self.check_block(&unit.block);
+        for item in unit.get_items() {
+            self.check_item(item);
+        }
     }
 
     fn check_expression(&mut self, expr: &BaseExpression) {
@@ -57,10 +59,23 @@ pub trait ASTVisitor {
         }
     }
 
+    fn check_item(&mut self, item: &Item) {
+        match *item {
+            Item::FnDeclaration(ref decl) => {
+                self.check_fn_declaration(decl)
+            }
+        }
+    }
+
     fn check_block(&mut self, block: &Block) {
         for stmt in &block.statements {
             self.check_statement(stmt);
         }
+    }
+
+    #[inline]
+    fn check_fn_declaration(&mut self, decl: &FnDeclaration) {
+        self.check_block(decl.get_block())
     }
 
     #[inline]

--- a/src/parse/ast_visitor.rs
+++ b/src/parse/ast_visitor.rs
@@ -32,12 +32,15 @@ pub trait ASTVisitor {
             },
             BaseExpression::UnaryOp(ref unary_op) => {
                 self.check_unary_op(unary_op)
-            },
+            }
             BaseExpression::VariableRef(ref var_ref) => {
                 self.check_var_ref(var_ref)
             }
             BaseExpression::IfExpression(ref if_expr) => {
                 self.check_if_expr(if_expr)
+            }
+            BaseExpression::FnCall(ref fn_call) => {
+                self.check_fn_call(fn_call)
             }
         }
     }
@@ -137,5 +140,10 @@ pub trait ASTVisitor {
         self.check_expression(if_expr.get_condition());
         self.check_expression(if_expr.get_true_expr());
         self.check_expression(if_expr.get_else());
+    }
+
+    fn check_fn_call(&mut self, fn_call: &FnCall) {
+        self.check_var_ref(fn_call.get_name());
+        
     }
 }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -4,6 +4,7 @@ pub mod ast;
 mod parser;
 mod ast_visitor;
 mod verify;
+mod types;
 pub mod symbol;
 
 #[cfg(test)]

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -352,6 +352,8 @@ impl<T: Tokenizer> Parser<T> {
 
             (Symbol, tokens::Percent) => BinOpExprSymbol::with_precedence(Precedence::Modulo),
 
+            (Symbol, tokens::LeftParen) => Rc::new(FnCallParser { }) as Rc<InfixParser<Expression, T>>,
+
             (Symbol, tokens::LeftAngle) => BinOpExprSymbol::with_precedence(Precedence::EqualityCompare),
             (Symbol, tokens::RightAngle) => BinOpExprSymbol::with_precedence(Precedence::EqualityCompare),
             (Symbol, tokens::LessThanEquals) => BinOpExprSymbol::with_precedence(Precedence::EqualityCompare),

--- a/src/parse/symbol/expression/assignment.rs
+++ b/src/parse/symbol/expression/assignment.rs
@@ -5,7 +5,7 @@ use parse::{Parser, ParseResult, ParseError};
 use parse::ast::*;
 use parse::symbol::{InfixParser, Precedence};
 
-/// Parses a declaration/// Parses an assignment expresion.
+/// Parses an assignment expresion.
 ///
 /// # Examples
 /// ```text

--- a/src/parse/symbol/expression/fn_call.rs
+++ b/src/parse/symbol/expression/fn_call.rs
@@ -1,0 +1,55 @@
+//! Function call - inline `(`
+
+use lex::{Token, Tokenizer, TokenType, TokenData};
+use parse::ast::*;
+use parse::{Parser, ParseResult, ParseError};
+use parse::symbol::{InfixParser, Precedence};
+
+/// Parses function calls by handling `(` as in infix operator.
+///
+/// # Examples
+/// ```text
+/// foo(bar    :     otherFnCall(),     baz    )
+///    >^ident ^take ^expr        ^take ^ident ^take
+/// ```
+#[derive(Debug)]
+pub struct FnCallParser { }
+impl<T: Tokenizer> InfixParser<Expression, T> for FnCallParser {
+    fn parse(&self, parser: &mut Parser<T>,
+             left: Expression, token: Token) -> ParseResult<Expression> {
+        debug_assert!(token.get_text() == tokens::LeftParen,
+            "FnCallParser: called on token {:?}", token);
+
+        let lvalue = try!(left.expect_identifier());
+
+        let mut called_args = Vec::new();
+        let mut arg_name = true;
+        loop {
+            if parser.peek().get_text() == tokens::RightParen {
+                parser.consume();
+                break
+            }
+            if arg_name {
+                parser.apply_indentation(IndentationRule::NegateDeindent);
+                let name = try!(parser.lvalue());
+                if parser.peek().get_text() == tokens::Colon {
+                    parser.consume();
+                    let value = parser.expression(Precedence::Min);
+                    called_args.push(CallArgument::var_value(name, value));
+                }
+                else {
+                    called_args.push(CallArgument::var_name(name));
+                }
+                arg_name = false;
+            }
+            else {
+                try!(parser.consume_name_indented(TokenType::Symbol,
+                                                  tokens::Comma,
+                                                  IndentationRule::NegateDeindent));
+                arg_name = true;
+            }
+        }
+        let call = FnCall::new(lvalue, token, called_args);
+        Ok(Expression::FnCall(call));
+    }
+}

--- a/src/parse/symbol/expression/fn_call.rs
+++ b/src/parse/symbol/expression/fn_call.rs
@@ -1,8 +1,8 @@
 //! Function call - inline `(`
 
-use lex::{Token, Tokenizer, TokenType, TokenData};
+use lex::{tokens, Token, Tokenizer, TokenType, TokenData};
 use parse::ast::*;
-use parse::{Parser, ParseResult, ParseError};
+use parse::{Parser, ParseResult, ParseError, IndentationRule};
 use parse::symbol::{InfixParser, Precedence};
 
 /// Parses function calls by handling `(` as in infix operator.
@@ -17,6 +17,7 @@ pub struct FnCallParser { }
 impl<T: Tokenizer> InfixParser<Expression, T> for FnCallParser {
     fn parse(&self, parser: &mut Parser<T>,
              left: Expression, token: Token) -> ParseResult<Expression> {
+        trace!("Parsing a function call of {:?}", left);
         debug_assert!(token.get_text() == tokens::LeftParen,
             "FnCallParser: called on token {:?}", token);
 
@@ -27,18 +28,33 @@ impl<T: Tokenizer> InfixParser<Expression, T> for FnCallParser {
         loop {
             if parser.peek().get_text() == tokens::RightParen {
                 parser.consume();
+                trace!("Function call complete");
                 break
             }
             if arg_name {
-                parser.apply_indentation(IndentationRule::NegateDeindent);
-                let name = try!(parser.lvalue());
-                if parser.peek().get_text() == tokens::Colon {
-                    parser.consume();
-                    let value = parser.expression(Precedence::Min);
-                    called_args.push(CallArgument::var_value(name, value));
+                trace!("Parsing an argument");
+                let arg = try!(parser.expression(Precedence::Min));
+                if let Expression::VariableRef(ident) = arg {
+                    trace!("Argument {} is probably named", ident.get_name());
+                    if parser.peek().get_text() == tokens::Colon {
+                        trace!("Argument {} is a named arg", ident.get_name());
+                        parser.consume();
+                        let arg_value = try!(parser.expression(Precedence::Min));
+                        called_args.push(CallArgument::var_value(ident, arg_value));
+                    }
+                    else {
+                        trace!("Adding inferred `{0} = {0}`", ident.get_name());
+                        called_args.push(CallArgument::var_name(ident));
+                    }
                 }
+                // TODO need to give better errors/handle multiple exprs
+                // being written
                 else {
-                    called_args.push(CallArgument::var_name(name));
+                    try!(parser.consume_name_indented(TokenType::Symbol,
+                                                      tokens::RightParen,
+                                                      IndentationRule::NegateDeindent));
+                    let fn_call = FnCall::single_expr(lvalue, token, arg);
+                    return Ok(Expression::FnCall(fn_call))
                 }
                 arg_name = false;
             }
@@ -49,7 +65,11 @@ impl<T: Tokenizer> InfixParser<Expression, T> for FnCallParser {
                 arg_name = true;
             }
         }
-        let call = FnCall::new(lvalue, token, called_args);
-        Ok(Expression::FnCall(call));
+        let call = FnCall::named(lvalue, token, called_args);
+        Ok(Expression::FnCall(call))
+    }
+
+    fn get_precedence(&self) -> Precedence {
+        Precedence::Paren
     }
 }

--- a/src/parse/symbol/expression/mod.rs
+++ b/src/parse/symbol/expression/mod.rs
@@ -5,6 +5,7 @@ mod assignment;
 mod assign_op;
 mod declaration;
 mod if_expr;
+mod fn_call;
 
 pub use self::literal::LiteralParser;
 pub use self::identifier::IdentifierParser;
@@ -13,6 +14,7 @@ pub use self::assignment::AssignmentParser;
 pub use self::assign_op::AssignOpParser;
 pub use self::declaration::DeclarationParser;
 pub use self::if_expr::IfExpressionParser;
+pub use self::fn_call::FnCallParser;
 
 #[cfg(test)]
 mod tests {

--- a/src/parse/symbol/item/function.rs
+++ b/src/parse/symbol/item/function.rs
@@ -1,0 +1,32 @@
+//! Parser for function declarations
+
+use lex::{tokens, Token, Tokenizer, TokenType, TokenData};
+use parse::{Parser, ParseResult, ParseError, IndentationRule};
+use parse::ast::*;
+use parse::symbol::{PrefixParser, Precedence};
+
+/// Parses a function declaration.
+///
+/// # Examples
+/// ```
+/// fn foo(bar, baz,
+///        bliz)
+///        -> int
+///     stmt*
+///
+/// fn foo (bar, baz, \+ bliz) -> int \- \+
+/// ```
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct FnDeclarationParser { }
+impl<T: Tokenizer> PrefixParser<Item, T> for FnDeclarationParser {
+    fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Item> {
+        debug_assert!(token.get_text() == tokens::Fn,
+            "Unexpected token {:?} to fn parser", token);
+        let _name = try!(parser.consume_type(TokenType::Ident));
+        /*let open_paren = try!(parser.consume_name_indented(TokenType::Symbol,
+                                                           tokens::LeftParen,
+                                                           IndentationRule::IgnoreIndent));*/
+        unimplemented!()
+    }
+}

--- a/src/parse/symbol/item/function.rs
+++ b/src/parse/symbol/item/function.rs
@@ -3,7 +3,7 @@
 use lex::{tokens, Token, Tokenizer, TokenType, TokenData};
 use parse::{Parser, ParseResult, ParseError, IndentationRule};
 use parse::ast::*;
-use parse::symbol::{PrefixParser, Precedence};
+use parse::symbol::{PrefixParser, Precedence, AssignmentParser, InfixParser};
 
 /// Parses a function declaration.
 ///
@@ -14,19 +14,50 @@ use parse::symbol::{PrefixParser, Precedence};
 ///        -> int
 ///     stmt*
 ///
-/// fn foo (bar, baz, \+ bliz) -> int \- \+
+/// fn foo (bar, baz, \+ bliz) -> int \- \+ stmt* \-
 /// ```
-
 #[derive(Debug, PartialEq, Clone)]
 pub struct FnDeclarationParser { }
 impl<T: Tokenizer> PrefixParser<Item, T> for FnDeclarationParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Item> {
         debug_assert!(token.get_text() == tokens::Fn,
             "Unexpected token {:?} to fn parser", token);
-        let _name = try!(parser.consume_type(TokenType::Ident));
-        /*let open_paren = try!(parser.consume_name_indented(TokenType::Symbol,
-                                                           tokens::LeftParen,
-                                                           IndentationRule::IgnoreIndent));*/
-        unimplemented!()
+        let name = try!(parser.lvalue());
+
+        // Args
+        // left paren cannot be indented
+        try!(parser.consume_name(TokenType::Symbol, tokens::LeftParen));
+        // S1 -> ")", done | name, S2
+        // S2 -> ",", S1 | ")", done
+        let mut args = Vec::new();
+        let mut arg_name = true;
+        loop {
+            if parser.peek().get_text() == tokens::RightParen {
+                parser.consume(); // right paren
+                break
+            }
+            // name
+            if arg_name {
+                parser.apply_indentation(IndentationRule::NegateDeindent);
+                let name = try!(parser.lvalue());
+                args.push(name);
+                arg_name = false;
+            }
+            // comma
+            else {
+                try!(parser.consume_name_indented(TokenType::Symbol,
+                                                  tokens::Comma,
+                                                  IndentationRule::NegateDeindent));
+                arg_name = true;
+            }
+        }
+        // TODO -> result type
+
+        // Function body
+        try!(parser.consume_type(TokenType::BeginBlock));
+        let block = try!(parser.block());
+
+        let decl = FnDeclaration::new(token, name, args, block);
+        Ok(Item::FnDeclaration(decl))
     }
 }

--- a/src/parse/symbol/item/mod.rs
+++ b/src/parse/symbol/item/mod.rs
@@ -1,0 +1,3 @@
+mod function;
+
+pub use self::function::FnDeclarationParser;

--- a/src/parse/symbol/mod.rs
+++ b/src/parse/symbol/mod.rs
@@ -1,9 +1,11 @@
 mod expression;
 mod statement;
+mod item;
 mod precedence;
 
 pub use self::expression::*;
 pub use self::statement::*;
+pub use self::item::*;
 pub use self::precedence::Precedence;
 
 use std::rc::Rc;

--- a/src/parse/symbol/precedence.rs
+++ b/src/parse/symbol/precedence.rs
@@ -25,7 +25,7 @@ pub enum Precedence {
     NumericPrefix,
     /// The `not` keyword
     NotKeyword,
-    /// Parens binder
+    /// Parens binder, used for both prefix and infix fns
     Paren,
     /// Extra value on the end
     Max

--- a/src/parse/tests.rs
+++ b/src/parse/tests.rs
@@ -90,36 +90,21 @@ pub fn parse_fails() {
 #[test]
 fn parse_examples() {
     let inputs = &[
-r#"let mut x = 0
-if x + 0
-    x += 1
-x"#,
-
-
-r#"let mut x = 5
-if x + 5
-    x + 1
-else
-    x"#,
-
-r#"let mut x = 5
-if x + 5
-    x + 1
-else if x - 5
-    x + 1
-else if x * 5
-    x - 1
-else
-    x - 1
+r#"
+fn fib(x)
+    if x <= 2
+        1
+    else
+        fib(x - 1) + fib(x - 2)
 "#
 ];
-    //::env_logger::LogBuilder::new()
-    //    .parse("TRACE")
-    //    .init()
-    //    .unwrap();
+    ::env_logger::LogBuilder::new()
+        .parse("TRACE")
+        .init()
+        .unwrap();
     for input in inputs {
         let mut parser = parser(input);
         trace!("Parsing input {:?}", input);
-        println!("{:#?}", parser.parse_unit().unwrap());
+        trace!("Resulting program:\n{:#?}", parser.parse_unit().unwrap());
     }
 }

--- a/src/parse/tests.rs
+++ b/src/parse/tests.rs
@@ -88,15 +88,17 @@ pub fn parse_fails() {
 }
 
 #[test]
-fn parse_examples() {
+fn parse_example() {
     let inputs = &[
 r#"
-fn fib(x)
-    if x <= 2
-        1
+fn factHelper(acc, n)
+    if n == 0
+        acc
     else
-        fib(x - 1) + fib(x - 2)
-"#
+        factHelper(acc: acc * n, n: n - 1)
+fn fact(n)
+    factHelper(n: n, acc: 1)
+"#,
 ];
     ::env_logger::LogBuilder::new()
         .parse("TRACE")
@@ -105,6 +107,6 @@ fn fib(x)
     for input in inputs {
         let mut parser = parser(input);
         trace!("Parsing input {:?}", input);
-        trace!("Resulting program:\n{:#?}", parser.parse_unit().unwrap());
+        trace!("Resulting program:\n{:#?}", parser.parse_unit());
     }
 }

--- a/src/parse/types/mod.rs
+++ b/src/parse/types/mod.rs
@@ -1,0 +1,3 @@
+mod types;
+
+pub use self::types::*;

--- a/src/parse/types/types.rs
+++ b/src/parse/types/types.rs
@@ -1,0 +1,32 @@
+//! Definition of types in protosnirk
+
+use std::collections::HashMap;
+
+/// Representation of types in protosnirk
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum Type {
+    /// `()`
+    Empty,
+    /// Standard type for now
+    Float,
+    /// Function - only used in declarations
+    Fn(FnType)
+}
+
+/// Type representation of functions in protosnirk
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct FnType {
+    return_type: Box<Type>,
+    args: HashMap<String, Type>
+}
+impl FnType {
+    pub fn new(return_type: Box<Type>, args: HashMap<String, Type>) -> FnType {
+        FnType { return_type: return_type, args: args }
+    }
+    pub fn get_return(&self) -> &Type {
+        &self.return_type
+    }
+    pub fn get_args(&self) -> &HashMap<String, Type> {
+        &self.args
+    }
+}

--- a/src/parse/types/types.rs
+++ b/src/parse/types/types.rs
@@ -12,21 +12,38 @@ pub enum Type {
     /// Function - only used in declarations
     Fn(FnType)
 }
+impl Type {
+    pub fn expect_fn(self) -> FnType {
+        match self {
+            Type::Fn(inner) => inner,
+            other => panic!("`expect_fn` called on {:?}", other)
+        }
+    }
+}
 
 /// Type representation of functions in protosnirk
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FnType {
     return_type: Box<Type>,
-    args: HashMap<String, Type>
+    // Order must be preserved
+    args: Vec<(String, Type)>
 }
 impl FnType {
-    pub fn new(return_type: Box<Type>, args: HashMap<String, Type>) -> FnType {
+    pub fn new(return_type: Box<Type>, args: Vec<(String, Type)>) -> FnType {
         FnType { return_type: return_type, args: args }
     }
     pub fn get_return(&self) -> &Type {
         &self.return_type
     }
-    pub fn get_args(&self) -> &HashMap<String, Type> {
+    pub fn get_args(&self) -> &[(String, Type)] {
         &self.args
+    }
+    pub fn get_arg(&self, name: &str) -> Option<(usize, Type)> {
+        for (ix, arg) in self.args.iter().enumerate() {
+            if arg.0 == name {
+                return Some((ix, arg.1.clone()))
+            }
+        }
+        return None
     }
 }

--- a/src/parse/verify/checker/usage_checker.rs
+++ b/src/parse/verify/checker/usage_checker.rs
@@ -13,13 +13,15 @@ impl UsageChecker {
             debug_assert!(!(!sym.is_mutable() && sym.is_mutated()),
                 "Did not expect immutable {:?} to be mutated", sym);
             if !sym.is_used() {
-                let err_message = format!("Variable {} is declared but never used",
+                let err_message = format!("{} {} is declared but never used",
+                    sym.get_source().get_name(),
                     sym.get_declaration().text);
                 warns.add_warning(
                     VerifyError::new(sym.get_declaration().clone(), vec![], err_message));
             }
             if sym.is_mutable() && !sym.is_mutated() {
-                let err_message = format!("Variable {} is declared mutable but never mutated",
+                let err_message = format!("{} {} is declared mutable but never mutated",
+                    sym.get_source().get_name(),
                     sym.get_declaration().text);
                 warns.add_warning(
                     VerifyError::new(sym.get_declaration().clone(), vec![], err_message));

--- a/src/parse/verify/scope.rs
+++ b/src/parse/verify/scope.rs
@@ -125,6 +125,13 @@ impl SymbolTableBuilder {
         &mut self.scopes[last_ix].insert(name, value);
     }
 
+    /// Define a variable in the global scope
+    pub fn define_global(&mut self, name: String, value: ScopeIndex) {
+        debug_assert!(!self.scopes.is_empty(),
+            "Attempted to define a global {} with no scopes", name);
+        &mut self.scopes[0].insert(name, value);
+    }
+
     /// Get a variable from any scope
     pub fn get(&self, name: &str) -> Option<&ScopeIndex> {
         trace!("Searching for {} in {:#?}", name, self);

--- a/src/parse/verify/symbol.rs
+++ b/src/parse/verify/symbol.rs
@@ -1,29 +1,42 @@
 //! Symbol table containing information about a given variable declaration
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
 
 use lex::Token;
 use parse::verify::scope::ScopeIndex;
-use parse::ast::Declaration;
+use parse::ast::{Declaration, Identifier};
+use parse::types::Type;
+
 
 /// Symbol stored in the symbol table
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Symbol {
+    /// Unique index for symbol
     index: ScopeIndex,
+    /// Cloned token of symbol (i.e. for viewing source)
     decl_token: Token,
-    mutable: bool,
+    /// Whether the symbol has been used
     used: bool,
-    mutated: bool
+    /// Whether the symbol is mutable (tracked per-reference)
+    mutable: bool,
+    /// Whether the symbol has been mutated
+    mutated: bool,
+    /// The type of the symbol
+    type_: Type,
+    /// The source of the symbol
+    source: Source
 }
 impl Symbol {
-    pub fn new(index: ScopeIndex, token: Token, mutable: bool) -> Symbol {
+    pub fn new(index: ScopeIndex, token: Token, mutable: bool, type_: Type, source: Source) -> Symbol {
         Symbol {
             decl_token: token,
             index: index,
             mutable: mutable,
             used: false,
-            mutated: false
+            mutated: false,
+            type_: type_,
+            source: source,
         }
     }
     pub fn from_declaration(decl: &Declaration, index: ScopeIndex) -> Symbol {
@@ -32,9 +45,34 @@ impl Symbol {
             index: index,
             mutable: decl.mutable,
             used: false,
-            mutated: false
+            mutated: false,
+            type_: Type::Float,
+            source: Source::Variable,
         }
     }
+    pub fn from_parameter(ident: &Identifier, index: ScopeIndex) -> Symbol {
+        Symbol {
+            decl_token: ident.get_token().clone(),
+            index: index,
+            mutable: false, // Just gonna strait up refuse mutable parameters
+            mutated: false,
+            used: false,
+            type_: Type::Float,
+            source: Source::Parameter,
+        }
+    }
+    pub fn from_fn_decl(ident: &Identifier, index: ScopeIndex, type_: Type) -> Symbol {
+        Symbol {
+            decl_token: ident.get_token().clone(),
+            index: index,
+            mutable: false,
+            mutated: false,
+            used: false,
+            type_: type_,
+            source: Source::DeclaredFn,
+        }
+    }
+
     pub fn get_index(&self) -> &ScopeIndex {
         &self.index
     }
@@ -55,5 +93,31 @@ impl Symbol {
     }
     pub fn set_used(&mut self) {
         self.used = true;
+    }
+    pub fn get_type(&self) -> &Type {
+        &self.type_
+    }
+    pub fn get_source(&self) -> Source {
+        self.source
+    }
+}
+
+/// Source of a particular symbol
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Source {
+    /// The symbol was declared as a variable
+    Variable,
+    /// The symbol was declared as a fn parameter
+    Parameter,
+    /// The symbol was declared as a function
+    DeclaredFn,
+}
+impl Source {
+    pub fn get_name(self) -> &'static str {
+        match self {
+            Source::Variable => "variable",
+            Source::Parameter => "function parameter",
+            Source::DeclaredFn => "declared function"
+        }
     }
 }


### PR DESCRIPTION
Protosnirk is now Turing complete!

- Functions are declared with the `fn` keyword
- Programs are now composed of a series of function declarations (`Item`s) instead of a `Block`
- Inline and block forms available (`fn name(args) =>`)
- Call-by-param-name instead of call-by-param-order
## Examples:
```text
// Params don't have types yet, must all be floats
fn factHelper(n, acc)
    if n <= 1
        acc
    else
        // named parameters, order doesn't matter
        factHelper(n: n - 1, acc: acc * n)
fn fact(n)
    // `n` here is short for `n: n`
    factHelper(n, acc: 1)

// Inline function!
fn abs(x) if x >= 0 => x else -x
```
## Known issues
- Passing in the name of a function as an argument will cause the compilation code to panic (waiting on actual type checking)
- Functions can't be called in the code before they're declared (also waiting on a type check pass)

## Coming next
Either a type checking/inference pass, an actual test suite, or JIT support