### PR TITLE
Add repository link in cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "protosnirk"
-description = "An in-progress simple programming language implemented in Rust"
+description = "An in-progress programming language implemented in Rust"
 version = "0.0.1"
-repository = ""
-keywords = ["protosnirk", "programming", "scripting", "language"]
+repository = "https://github.com/immington-industries/protosnirk"
+keywords = ["protosnirk", "snirk", "programming", "language"]
 readme = "README.md"
 authors = ["Snirk Immington <snirk.immington@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Attempting to follow [rust API guidelines](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#cargotoml-includes-all-common-metadata-c-metadata) in `Cargo.toml` - added `repository` entry and updated `keywords`.