### PR TITLE
Remove chaining if expr limitation

### DIFF
--- a/src/parse/symbol/expression/if_expr.rs
+++ b/src/parse/symbol/expression/if_expr.rs
@@ -31,10 +31,6 @@ impl<T: Tokenizer> PrefixParser<Expression, T> for IfExpressionParser {
         trace!("Parsed sucess half of conditional");
         try!(parser.consume_name(TokenType::Keyword, tokens::Else));
         trace!("Parsing else half of conditional");
-        if parser.peek().get_text() == tokens::If {
-            let error = "Cannot have an `else if` via inline if expression";
-            return Err(ParseError::LazyString(error.to_string()))
-        }
         let else_expr = try!(parser.expression(Precedence::Min));
         let if_expr = IfExpression::new(token,
                                         Box::new(condition),

--- a/src/parse/symbol/expression/if_expr.rs
+++ b/src/parse/symbol/expression/if_expr.rs
@@ -19,7 +19,8 @@ use parse::symbol::{PrefixParser, Precedence};
 #[derive(Debug)]
 pub struct IfExpressionParser { }
 impl<T: Tokenizer> PrefixParser<Expression, T> for IfExpressionParser {
-    fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Expression> {
+    fn parse(&self, parser: &mut Parser<T>, token: Token)
+            -> ParseResult<Expression> {
         debug_assert!(token.text == "if",
             "Invlaid token {:?} in IfExpressionParser", token);
         trace!("Parsing conditional of if expression");


### PR DESCRIPTION
This single expression `fib` is a test case on the typeck branch:
```
fn fib(n: float) -> float
   if n < 0 => n else if n < 3 => 1 else fib(n - 1) + fib(n - 2)
```

However, it's not possible to write without parens:
```
fn fib(n: float) -> float
    if n < 0 => n else (if n <= 2 => 1 else fib(n - 1) + fib(n - 2))
```

Due to the parser specifically emitting an error. However, I do not believe this artificial limitation is useful. Expressions of the form:

```
if c1 => e1 else if c2 => e2 else if c3 => e3 else e4
```
(a poor man's `match`) may end up nesting in a way that `if` blocks don't:
```
if c1
    e1
else
    if c2
        e2
    else
        if c3
            e3
        else
            e4
```
But that's okay. This parsing still preserves short-circuiting and requires all `e1`-`e4` to be of the same type.

