### PR TITLE
Enforce the Law of Demeter

### DIFF
--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -148,10 +148,10 @@ impl Literal {
 /// Maths style binary operations (may be split up later)
 #[derive(Debug, PartialEq, Clone)]
 pub struct BinaryOperation {
-    pub operator: Operator,
-    pub op_token: Token,
-    pub left: Box<Expression>,
-    pub right: Box<Expression>
+    operator: Operator,
+    op_token: Token,
+    left: Box<Expression>,
+    right: Box<Expression>
 }
 impl BinaryOperation {
     pub fn new(operator: Operator, op_token: Token,
@@ -177,9 +177,9 @@ impl BinaryOperation {
 /// Unary operation
 #[derive(Debug, PartialEq, Clone)]
 pub struct UnaryOperation {
-    pub operator: Operator,
-    pub op_token: Token,
-    pub expression: Box<Expression>
+    operator: Operator,
+    op_token: Token,
+    expression: Box<Expression>
 }
 impl UnaryOperation {
     /// Creates a new unary operation
@@ -203,9 +203,9 @@ impl UnaryOperation {
 /// Variable declaration
 #[derive(Debug, PartialEq, Clone)]
 pub struct Declaration {
-    pub mutable: bool,
-    pub ident: Identifier,
-    pub value: Box<Expression>,
+    mutable: bool,
+    ident: Identifier,
+    value: Box<Expression>,
     type_decl: Option<TypeExpression>
 }
 impl Declaration {
@@ -247,8 +247,8 @@ impl Declaration {
 /// An identifier is assigned to a value
 #[derive(Debug, PartialEq, Clone)]
 pub struct Assignment {
-    pub lvalue: Identifier,
-    pub rvalue: Box<Expression>
+    lvalue: Identifier,
+    rvalue: Box<Expression>
 }
 impl Assignment {
     pub fn new(name: Identifier, value: Box<Expression>) -> Assignment {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -31,7 +31,7 @@ use lex::Token;
 /// Basic identifier type
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Identifier {
-    pub token: Token,
+    token: Token,
     id: RefCell<ScopedId>,
 }
 impl Identifier {
@@ -39,7 +39,7 @@ impl Identifier {
         Identifier { token, id: RefCell::default() }
     }
     pub fn get_name(&self) -> &str {
-        &self.token.text
+        &self.token.get_text()
     }
     pub fn get_token(&self) -> &Token {
         &self.token

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -61,8 +61,8 @@ impl Return {
 /// Do <block> statement.
 #[derive(Debug, PartialEq, Clone)]
 pub struct DoBlock {
-    pub do_token: Token,
-    pub block: Box<Block>
+    do_token: Token,
+    block: Box<Block>
 }
 impl DoBlock {
     pub fn new(token: Token, block: Box<Block>) -> DoBlock {
@@ -110,8 +110,8 @@ impl DoBlock {
 /// The conditionals are in a list instead of nested.
 #[derive(Debug, PartialEq, Clone)]
 pub struct IfBlock {
-    pub conditionals: Vec<Conditional>,
-    pub else_block: Option<(Token, Block)>,
+    conditionals: Vec<Conditional>,
+    else_block: Option<(Token, Block)>,
     scoped_id: RefCell<ScopedId>,
     source: RefCell<Option<ScopedId>>
 }
@@ -119,9 +119,9 @@ pub struct IfBlock {
 /// A basic conditional
 #[derive(Debug, PartialEq, Clone)]
 pub struct Conditional {
-    pub if_token: Token,
-    pub condition: Expression,
-    pub block: Block,
+    if_token: Token,
+    condition: Expression,
+    block: Block,
 }
 
 impl IfBlock {

--- a/src/compile/module_compiler.rs
+++ b/src/compile/module_compiler.rs
@@ -391,13 +391,13 @@ impl<'ctx, 'b, M> ExpressionVisitor for ModuleCompiler<'ctx, 'b, M>
     }
 
     fn visit_unary_op(&mut self, unary_op: &UnaryOperation) {
-        debug_assert!(unary_op.operator == Operator::Subtraction,
-            "Invalid unary operator {:?}", unary_op.operator);
+        debug_assert!(unary_op.get_operator() == Operator::Subtraction,
+            "Invalid unary operator {:?}", unary_op.get_operator());
         self.visit_expression(unary_op.get_inner());
         let inner_value = self.ir_code.pop()
             .expect("Did not generate value inside unary op");
         let builder = self.builder;
-        let (value, type_) = match unary_op.operator {
+        let (value, type_) = match unary_op.get_operator() {
             Operator::Subtraction =>
                 (builder.build_neg(&inner_value, "negate"),
                 Type::double(&self.context)),

--- a/src/lex/token.rs
+++ b/src/lex/token.rs
@@ -17,11 +17,11 @@ use lex::{TextLocation, CowStr};
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct Token {
     /// Location of the token in a file
-    pub location: TextLocation,
+    pub(crate) location: TextLocation,
     /// Text of the token at that location
-    pub text: CowStr,
+    pub(crate) text: CowStr,
     /// Additional data (type/literal) provided by the lexer
-    pub data: TokenData
+    pub(crate) data: TokenData
 }
 
 impl Token {

--- a/src/lex/tokenizer.rs
+++ b/src/lex/tokenizer.rs
@@ -381,42 +381,42 @@ impl<I: Iterator<Item=char>> IterTokenizer<I> {
                 token_string.pop();
                 let parsed: f64 = token_string.parse()
                     .expect("Couldn't parse float");
-                return Token {
-                    location: location,
-                    text: Cow::Owned(token_string),
-                    data: TokenData::NumberLiteral(parsed)
-                }
+                return Token::new(
+                    Cow::Owned(token_string),
+                    location,
+                    TokenData::NumberLiteral(parsed)
+                )
             }
             self.take_while(char::is_number, &mut token_string);
         }
         if self.iter.peek().unwrap_or(' ').to_lowercase().collect::<String>() != "e" {
             let parsed: f64 = token_string.parse()
                 .expect("Couldn't parse float");
-            return Token {
-                location: location,
-                text: Cow::Owned(token_string),
-                data: TokenData::NumberLiteral(parsed)
-            }
+            return Token::new(
+                Cow::Owned(token_string),
+                location,
+                TokenData::NumberLiteral(parsed)
+            )
         }
         token_string.push(self.iter.next().expect("Checked expect"));
         // Need numbers after the E
         if !self.iter.peek().unwrap_or(' ').is_number() {
             let parsed: f64 = token_string.parse()
                 .expect("Couldn't parse float");
-            return Token {
-                location: location,
-                text: Cow::Owned(token_string),
-                data: TokenData::NumberLiteral(parsed)
-            }
+            return Token::new(
+                Cow::Owned(token_string),
+                location,
+                TokenData::NumberLiteral(parsed)
+            )
         }
         self.take_while(char::is_number, &mut token_string);
         let parsed: f64 = token_string.parse()
             .expect("Couldn't parse float");
-        return Token {
-            location: location,
-            text: Cow::Owned(token_string),
-            data: TokenData::NumberLiteral(parsed)
-        }
+        return Token::new(
+            Cow::Owned(token_string),
+            location,
+            TokenData::NumberLiteral(parsed)
+        )
     }
 
     /// Continue taking characters while a condition is met

--- a/src/parse/symbol/expression/assign_op.rs
+++ b/src/parse/symbol/expression/assign_op.rs
@@ -23,7 +23,7 @@ impl<T: Tokenizer> InfixParser<Expression, T> for AssignOpParser {
         let lvalue = try!(left.expect_identifier());
         let right_expr = try!(parser.expression(Precedence::Min));
         let right_value = try!(right_expr.expect_value());
-        let operator = try!(parser.operator(token.get_type(), &token.text));
+        let operator = try!(parser.operator(token.get_type()));
         // We parse it here into an expanded expression.
         let right_expr = Expression::BinaryOp(BinaryOperation::new(
             operator,

--- a/src/parse/symbol/expression/assignment.rs
+++ b/src/parse/symbol/expression/assignment.rs
@@ -17,8 +17,8 @@ pub struct AssignmentParser { }
 impl<T: Tokenizer> InfixParser<Expression, T> for AssignmentParser {
     fn parse(&self, parser: &mut Parser<T>,
              left: Expression, _token: Token) -> ParseResult<Expression> {
-        debug_assert!(_token.text == tokens::Equals,
-                      "Assign parser called with non-assign token {:?}", _token);
+        debug_assert!(_token.get_type() == TokenType::Equals,
+            "Assign parser called with non-assign token {:?}", _token);
         let ident = try!(left.expect_identifier());
         let right_expr = try!(parser.expression(Precedence::Assign));
         let right = try!(right_expr.expect_value());

--- a/src/parse/symbol/expression/if_expr.rs
+++ b/src/parse/symbol/expression/if_expr.rs
@@ -21,7 +21,7 @@ pub struct IfExpressionParser { }
 impl<T: Tokenizer> PrefixParser<Expression, T> for IfExpressionParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token)
             -> ParseResult<Expression> {
-        debug_assert!(token.text == "if",
+        debug_assert!(token.get_text() == "if",
             "Invlaid token {:?} in IfExpressionParser", token);
         trace!("Parsing conditional of if expression");
         let condition = try!(parser.expression(Precedence::Min));

--- a/src/parse/symbol/expression/mod.rs
+++ b/src/parse/symbol/expression/mod.rs
@@ -35,7 +35,7 @@ impl<T: Tokenizer> InfixParser<Expression, T> for BinOpExprSymbol {
     fn parse(&self, parser: &mut Parser<T>,
              left: Expression, token: Token) -> ParseResult<Expression> {
         let right: Expression = try!(parser.expression(self.precedence));
-        let bin_operator = try!(parser.operator(token.get_type(), &token.text));
+        let bin_operator = try!(parser.operator(token.get_type()));
         Ok(Expression::BinaryOp(
             BinaryOperation::new(bin_operator, token, Box::new(left), Box::new(right))))
     }
@@ -62,7 +62,7 @@ impl<T: Tokenizer> PrefixParser<Expression, T> for UnaryOpExprSymbol {
              parser: &mut Parser<T>, token: Token) -> ParseResult<Expression> {
         let right_expr = try!(parser.expression(self.precedence));
         let right_value = try!(right_expr.expect_value());
-        let operator = try!(parser.operator(token.get_type(), &token.text));
+        let operator = try!(parser.operator(token.get_type()));
         Ok(Expression::UnaryOp(UnaryOperation::new(operator, token, Box::new(right_value))))
     }
 }

--- a/src/parse/symbol/statement/do_block.rs
+++ b/src/parse/symbol/statement/do_block.rs
@@ -20,7 +20,7 @@ use parse::symbol::PrefixParser;
 pub struct DoBlockParser { }
 impl<T: Tokenizer> PrefixParser<Statement, T> for DoBlockParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Statement> {
-        debug_assert!(token.text == "do",
+        debug_assert!(token.get_text() == "do",
             "Invalid token {:?} in DoBlockParser", token);
         if parser.next_type() == TokenType::BeginBlock {
             parser.consume();

--- a/src/parse/symbol/statement/return_stmt.rs
+++ b/src/parse/symbol/statement/return_stmt.rs
@@ -16,7 +16,7 @@ use parse::symbol::{PrefixParser, Precedence};
 pub struct ReturnParser { }
 impl<T: Tokenizer> PrefixParser<Statement, T> for ReturnParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Statement> {
-        debug_assert!(token.text == tokens::Return,
+        debug_assert!(token.get_text() == tokens::Return,
                       "Return parser called with non-return {:?}", token);
         // If the next statement is on a newline then empty return.
         // Also empty return if next token is deindent

--- a/src/parse/tests.rs
+++ b/src/parse/tests.rs
@@ -25,9 +25,9 @@ pub fn eof_parser() -> Parser<IterTokenizer<Chars<'static>>> {
 
 /// Check that two tokens are equal, without looking at locatoin
 pub fn token_eq(expected: Token, got: Token) {
-    assert_eq!(expected.data, got.data,
+    assert_eq!(expected.get_data(), got.get_data(),
         "token_eq: {:?} != {:?}", expected, got);
-    assert_eq!(expected.text, got.text,
+    assert_eq!(expected.get_text(), got.get_text(),
         "token_eq: {:?} != {:?}", expected, got);
 }
 


### PR DESCRIPTION
This PR removes all `pub` fields from structures in the compiler (aside from `Token` which is `pub(crate)` until we remove the awful unit tests).

This follows the [Law of Demeter](https://en.wikipedia.org/wiki/Law_of_Demeter) in the simple way of "don't call a field of a field". This is not a pattern I want to encourage in Snirk, either.  