### PR TITLE
Remove the `get_` from all the getters

### DIFF
--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -99,7 +99,7 @@ impl Literal {
     /// Creates a new boolean literal from the given token and boolean value.
     pub fn new_bool(token: Token, value: bool) -> Literal {
         debug_assert!(
-            match *token.get_data() {
+            match *token.data() {
                 TokenData::BoolLiteral(_) => true, _ => false
             },
             "Literal bool created with bad token {:?}", token);
@@ -112,7 +112,7 @@ impl Literal {
     /// Creates a new unit type literal `()` from the given token.
     pub fn new_unit(token: Token) -> Literal {
         debug_assert!(
-            match *token.get_data() {
+            match *token.data() {
                 TokenData::UnitLiteral => true, _ => false
             },
             "Literal unit created with bad token {:?}", token);
@@ -125,7 +125,7 @@ impl Literal {
     /// Creates a new floating point literal from the given token and value.
     pub fn new_f64(token: Token, value: f64) -> Literal {
         debug_assert!(
-            match *token.get_data() {
+            match *token.data() {
                 TokenData::NumberLiteral(_) => true, _ => false
             },
             "Literal f64 called with bad token {:?}", token);
@@ -136,11 +136,11 @@ impl Literal {
     }
 
     /// Gets the `LiteralValue` of this literal expression.
-    pub fn get_value(&self) -> &LiteralValue {
+    pub fn value(&self) -> &LiteralValue {
         &self.value
     }
     /// Gets the token of this literal.
-    pub fn get_token(&self) -> &Token {
+    pub fn token(&self) -> &Token {
         &self.token
     }
 }
@@ -163,13 +163,13 @@ impl BinaryOperation {
             right: right
         }
     }
-    pub fn get_operator(&self) -> Operator {
+    pub fn operator(&self) -> Operator {
         self.operator
     }
-    pub fn get_left(&self) -> &Expression {
+    pub fn left(&self) -> &Expression {
         &self.left
     }
-    pub fn get_right(&self) -> &Expression {
+    pub fn right(&self) -> &Expression {
         &self.right
     }
 }
@@ -192,10 +192,10 @@ impl UnaryOperation {
             expression: expression
         }
     }
-    pub fn get_operator(&self) -> Operator {
+    pub fn operator(&self) -> Operator {
         self.operator
     }
-    pub fn get_inner(&self) -> &Expression {
+    pub fn inner(&self) -> &Expression {
         &self.expression
     }
 }
@@ -215,28 +215,28 @@ impl Declaration {
                value: Box<Expression>) -> Declaration {
         Declaration { ident, mutable, type_decl, value }
     }
-    pub fn get_name(&self) -> &str {
-        &self.ident.get_name()
+    pub fn name(&self) -> &str {
+        &self.ident.name()
     }
-    pub fn get_value(&self) -> &Expression {
+    pub fn value(&self) -> &Expression {
         &self.value
     }
     pub fn is_mut(&self) -> bool {
         self.mutable
     }
-    pub fn get_ident(&self) -> &Identifier {
+    pub fn ident(&self) -> &Identifier {
         &self.ident
     }
-    pub fn get_token(&self) -> &Token {
-        self.ident.get_token()
+    pub fn token(&self) -> &Token {
+        self.ident.token()
     }
-    pub fn get_id<'a>(&'a self) -> Ref<'a, ScopedId> {
-        self.get_ident().get_id()
+    pub fn id<'a>(&'a self) -> Ref<'a, ScopedId> {
+        self.ident().id()
     }
     pub fn set_id(&self, id: ScopedId) {
-        self.get_ident().set_id(id);
+        self.ident().set_id(id);
     }
-    pub fn get_type_decl(&self) -> Option<&TypeExpression> {
+    pub fn type_decl(&self) -> Option<&TypeExpression> {
         self.type_decl.as_ref()
     }
     pub fn has_declared_type(&self) -> bool {
@@ -254,10 +254,10 @@ impl Assignment {
     pub fn new(name: Identifier, value: Box<Expression>) -> Assignment {
         Assignment { lvalue: name, rvalue: value }
     }
-    pub fn get_lvalue(&self) -> &Identifier {
+    pub fn lvalue(&self) -> &Identifier {
         &self.lvalue
     }
-    pub fn get_rvalue(&self) -> &Expression {
+    pub fn rvalue(&self) -> &Expression {
         &self.rvalue
     }
 }
@@ -282,16 +282,16 @@ impl IfExpression {
             else_expr: else_expr
         }
     }
-    pub fn get_token(&self) -> &Token {
+    pub fn token(&self) -> &Token {
         &self.if_token
     }
-    pub fn get_condition(&self) -> &Expression {
+    pub fn condition(&self) -> &Expression {
         &self.condition
     }
-    pub fn get_true_expr(&self) -> &Expression {
+    pub fn true_expr(&self) -> &Expression {
         &self.true_expr
     }
-    pub fn get_else(&self) -> &Expression {
+    pub fn else_expr(&self) -> &Expression {
         &self.else_expr
     }
 }
@@ -310,24 +310,24 @@ impl FnCall {
                args: Vec<CallArgument>) -> FnCall {
         FnCall { lvalue, paren_token: token, args }
     }
-    pub fn get_ident(&self) -> &Identifier {
+    pub fn ident(&self) -> &Identifier {
         &self.lvalue
     }
-    pub fn get_text(&self) -> &str {
-        self.get_ident().get_name()
+    pub fn text(&self) -> &str {
+        self.ident().name()
     }
-    pub fn get_token(&self) -> &Token {
+    pub fn token(&self) -> &Token {
         &self.paren_token
     }
-    pub fn get_args(&self) -> &[CallArgument] {
+    pub fn args(&self) -> &[CallArgument] {
         &self.args
     }
 
-    pub fn get_id<'a>(&'a self) -> Ref<'a, ScopedId> {
-        self.get_ident().get_id()
+    pub fn id<'a>(&'a self) -> Ref<'a, ScopedId> {
+        self.ident().id()
     }
     pub fn set_id(&self, id: ScopedId) {
-        self.get_ident().set_id(id);
+        self.ident().set_id(id);
     }
 }
 
@@ -343,11 +343,11 @@ impl CallArgument {
     }
 
     /// Gets the value of the CallArgument.
-    pub fn get_expression(&self) -> &Expression {
+    pub fn expression(&self) -> &Expression {
         &self.value
     }
 
-    pub fn get_name(&self) -> &Identifier {
+    pub fn name(&self) -> &Identifier {
         &self.param
     }
 

--- a/src/ast/item.rs
+++ b/src/ast/item.rs
@@ -19,7 +19,7 @@ impl Unit {
         Unit { items: items }
     }
     /// Gets the collection of exported items
-    pub fn get_items(&self) -> &[Item] {
+    pub fn items(&self) -> &[Item] {
         &self.items
     }
 }
@@ -55,34 +55,34 @@ impl BlockFnDeclaration {
         }
     }
     /// Get the `fn` token
-    pub fn get_token(&self) -> &Token {
+    pub fn token(&self) -> &Token {
         &self.fn_token
     }
     /// Get the identifier of the function
-    pub fn get_ident(&self) -> &Identifier {
+    pub fn ident(&self) -> &Identifier {
         &self.ident
     }
-    pub fn get_params(&self) -> &[(Identifier, TypeExpression)] {
+    pub fn params(&self) -> &[(Identifier, TypeExpression)] {
         &self.params
     } 
-    pub fn get_return_type(&self) -> &TypeExpression {
+    pub fn return_type(&self) -> &TypeExpression {
         &self.ret_ty
     }
     pub fn has_explicit_return_type(&self) -> bool {
         self.explicit_ret_ty
     }
-    pub fn get_id<'a>(&'a self) -> Ref<'a, ScopedId> {
-        self.ident.get_id()
+    pub fn id<'a>(&'a self) -> Ref<'a, ScopedId> {
+        self.ident.id()
     }
     pub fn set_id(&self, id: ScopedId) {
         self.ident.set_id(id);
     }
     /// Get the textual name of the function
-    pub fn get_name(&self) -> &str {
-        &self.ident.get_name()
+    pub fn name(&self) -> &str {
+        &self.ident.name()
     }
     /// Get the block inside the function
-    pub fn get_block(&self) -> &Block {
+    pub fn block(&self) -> &Block {
         &self.block
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -39,14 +39,14 @@ impl Identifier {
     pub fn new(token: Token) -> Self {
         Identifier { token, id: RefCell::default() }
     }
-    pub fn get_name(&self) -> &str {
-        &self.token.get_text()
+    pub fn name(&self) -> &str {
+        &self.token.text()
     }
-    pub fn get_token(&self) -> &Token {
+    pub fn token(&self) -> &Token {
         &self.token
     }
 
-    pub fn get_id<'a>(&'a self) -> Ref<'a, ScopedId> {
+    pub fn id<'a>(&'a self) -> Ref<'a, ScopedId> {
         self.id.borrow()
     }
 
@@ -83,16 +83,16 @@ impl Block {
         }
     }
 
-    pub fn get_stmts(&self) -> &[Statement] {
+    pub fn stmts(&self) -> &[Statement] {
         &self.statements
     }
-    pub fn get_id<'a>(&'a self) -> Ref<'a, ScopedId> {
+    pub fn id<'a>(&'a self) -> Ref<'a, ScopedId> {
         self.scope_id.borrow()
     }
     pub fn set_id(&self, id: ScopedId) {
         *self.scope_id.borrow_mut() = id;
     }
-    pub fn get_source<'a>(&'a self) -> Ref<'a, Option<ScopedId>> {
+    pub fn source<'a>(&'a self) -> Ref<'a, Option<ScopedId>> {
         self.source.borrow()
     }
     pub fn set_source(&self, source: ScopedId) {

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -50,10 +50,10 @@ impl Return {
             false
         }
     }
-    pub fn get_value(&self) -> Option<&Expression> {
+    pub fn value(&self) -> Option<&Expression> {
         self.value.as_ref().map(|expr| expr.as_ref())
     }
-    pub fn get_token(&self) -> &Token {
+    pub fn token(&self) -> &Token {
         &self.token
     }
 }
@@ -69,20 +69,20 @@ impl DoBlock {
         DoBlock { do_token: token, block: block }
     }
 
-    pub fn get_block(&self) -> &Block {
+    pub fn block(&self) -> &Block {
         &self.block
     }
 
-    pub fn get_id<'a>(&'a self) -> Ref<'a, ScopedId> {
-        self.block.get_id()
+    pub fn id<'a>(&'a self) -> Ref<'a, ScopedId> {
+        self.block.id()
     }
 
     pub fn set_id(&self, id: ScopedId) {
         self.block.set_id(id);
     }
 
-    pub fn get_source<'a>(&'a self) -> Ref<'a, Option<ScopedId>> {
-        self.block.get_source()
+    pub fn source<'a>(&'a self) -> Ref<'a, Option<ScopedId>> {
+        self.block.source()
     }
 
     pub fn set_source(&self, source: ScopedId) {
@@ -142,23 +142,23 @@ impl IfBlock {
     pub fn has_else(&self) -> bool {
         self.else_block.is_some()
     }
-    pub fn get_conditionals(&self) -> &Vec<Conditional> {
+    pub fn conditionals(&self) -> &Vec<Conditional> {
         &self.conditionals
     }
-    pub fn get_condition(&self) -> &Expression {
+    pub fn condition(&self) -> &Expression {
         &self.conditionals[0].condition
     }
-    pub fn get_else(&self) -> Option<&(Token, Block)> {
+    pub fn else_block(&self) -> Option<&(Token, Block)> {
         self.else_block.as_ref()
     }
-    pub fn get_id<'a>(&'a self) -> Ref<'a, ScopedId> {
+    pub fn id<'a>(&'a self) -> Ref<'a, ScopedId> {
         self.scoped_id.borrow()
     }
     pub fn set_id(&self, id: ScopedId) {
         *self.scoped_id.borrow_mut() = id;
     }
 
-    pub fn get_source<'a>(&'a self) -> Ref<'a, Option<ScopedId>> {
+    pub fn source<'a>(&'a self) -> Ref<'a, Option<ScopedId>> {
         self.source.borrow()
     }
     pub fn set_source(&self, source: ScopedId) {
@@ -179,18 +179,18 @@ impl Conditional {
             block: block
         }
     }
-    pub fn get_condition(&self) -> &Expression {
+    pub fn condition(&self) -> &Expression {
         &self.condition
     }
-    pub fn get_block(&self) -> &Block {
+    pub fn block(&self) -> &Block {
         &self.block
     }
-    pub fn get_token(&self) -> &Token {
+    pub fn token(&self) -> &Token {
         &self.if_token
     }
 
-    pub fn get_source<'a>(&'a self) -> Ref<'a, Option<ScopedId>> {
-        self.block.get_source()
+    pub fn source<'a>(&'a self) -> Ref<'a, Option<ScopedId>> {
+        self.block.source()
     }
 
     pub fn set_source(&self, source: ScopedId) {

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -19,9 +19,9 @@ pub enum TypeExpression {
 }
 
 impl TypeExpression {
-    pub fn get_id(&self) -> Ref<ScopedId> {
+    pub fn id(&self) -> Ref<ScopedId> {
         match self {
-            &TypeExpression::Named(ref named) => named.get_id()
+            &TypeExpression::Named(ref named) => named.id()
         }
     }
 }
@@ -43,16 +43,16 @@ impl NamedTypeExpression {
     }
 
     /// Gets the identifier of this type.
-    pub fn get_ident(&self) -> &Identifier {
+    pub fn ident(&self) -> &Identifier {
         &self.ident
     }
 
-    pub fn get_name(&self) -> &str {
-        self.ident.get_name()
+    pub fn name(&self) -> &str {
+        self.ident.name()
     }
 
-    pub fn get_id<'a>(&'a self) -> Ref<'a, ScopedId> {
-        self.ident.get_id()
+    pub fn id<'a>(&'a self) -> Ref<'a, ScopedId> {
+        self.ident.id()
     }
 
     pub fn set_id<'a>(&'a self, id: ScopedId) {

--- a/src/ast/visit/walk.rs
+++ b/src/ast/visit/walk.rs
@@ -7,7 +7,7 @@ use ast::visit::visitor::*;
 #[inline]
 pub fn walk_unit<V>(visitor: &mut V, unit: &Unit)
                 where V: ItemVisitor {
-    for item in unit.get_items() {
+    for item in unit.items() {
         visitor.visit_item(item);
     }
 }
@@ -16,14 +16,14 @@ pub fn walk_unit<V>(visitor: &mut V, unit: &Unit)
 #[inline]
 pub fn walk_fn_decl<V>(visitor: &mut V, fn_decl: &BlockFnDeclaration)
                     where V: BlockVisitor {
-    visitor.visit_block(fn_decl.get_block());
+    visitor.visit_block(fn_decl.block());
 }
 
 /// Visit each statement in the block.
 #[inline]
 pub fn walk_block<V>(visitor: &mut V, block: &Block)
                  where V: StatementVisitor {
-    for stmt in block.get_stmts() {
+    for stmt in block.stmts() {
         visitor.visit_stmt(stmt);
     }
 }
@@ -32,28 +32,28 @@ pub fn walk_block<V>(visitor: &mut V, block: &Block)
 #[inline]
 pub fn walk_if_expr<V>(visitor: &mut V, if_expr: &IfExpression)
                 where V: ExpressionVisitor {
-    visitor.visit_expression(if_expr.get_condition());
-    visitor.visit_expression(if_expr.get_true_expr());
-    visitor.visit_expression(if_expr.get_else());
+    visitor.visit_expression(if_expr.condition());
+    visitor.visit_expression(if_expr.true_expr());
+    visitor.visit_expression(if_expr.else_expr());
 }
 
 #[inline]
 pub fn walk_bin_op<V>(visitor: &mut V, bin_op: &BinaryOperation)
                   where V: ExpressionVisitor {
-    visitor.visit_expression(bin_op.get_left());
-    visitor.visit_expression(bin_op.get_right());
+    visitor.visit_expression(bin_op.left());
+    visitor.visit_expression(bin_op.right());
 }
 
 #[inline]
 pub fn walk_unary_op<V>(visitor: &mut V, un_op: &UnaryOperation)
                     where V: ExpressionVisitor {
-    visitor.visit_expression(un_op.get_inner());
+    visitor.visit_expression(un_op.inner());
 }
 
 #[inline]
 pub fn walk_return<V>(visitor: &mut V, ret: &Return)
                      where V: ExpressionVisitor {
-    if let Some(expr) = ret.get_value() {
+    if let Some(expr) = ret.value() {
         visitor.visit_expression(expr);
     }
 }
@@ -61,17 +61,17 @@ pub fn walk_return<V>(visitor: &mut V, ret: &Return)
 #[inline]
 pub fn walk_do_block<V>(visitor: &mut V, block: &DoBlock)
                         where V: BlockVisitor {
-    visitor.visit_block(block.get_block());
+    visitor.visit_block(block.block());
 }
 
 #[inline]
 pub fn walk_if_block<V>(visitor: &mut V, if_block: &IfBlock)
                         where V: BlockVisitor + ExpressionVisitor {
-    for cond in if_block.get_conditionals() {
-        visitor.visit_expression(cond.get_condition());
-        visitor.visit_block(cond.get_block());
+    for cond in if_block.conditionals() {
+        visitor.visit_expression(cond.condition());
+        visitor.visit_block(cond.block());
     }
-    if let Some(&(_, ref block)) = if_block.get_else() {
+    if let Some(&(_, ref block)) = if_block.else_block() {
         visitor.visit_block(block);
     }
 }

--- a/src/check/collector.rs
+++ b/src/check/collector.rs
@@ -25,23 +25,23 @@ impl ErrorCollector {
         self.lints.push(lint);
     }
 
-    pub fn get_errors(&self) -> &[CheckerError] {
+    pub fn errors(&self) -> &[CheckerError] {
         &self.errors
     }
-    pub fn get_warnings(&self) -> &[CheckerError] {
+    pub fn warnings(&self) -> &[CheckerError] {
         &self.warnings
     }
-    pub fn get_lints(&self) -> &[CheckerError] {
+    pub fn lints(&self) -> &[CheckerError] {
         &self.lints
     }
 
-    pub fn get_errors_mut(&mut self) -> &mut [CheckerError] {
+    pub fn errors_mut(&mut self) -> &mut [CheckerError] {
         &mut self.errors
     }
-    pub fn get_warnings_mut(&mut self) -> &mut [CheckerError] {
+    pub fn warnings_mut(&mut self) -> &mut [CheckerError] {
         &mut self.warnings
     }
-    pub fn get_lints_mut(&mut self) -> &mut [CheckerError] {
+    pub fn lints_mut(&mut self) -> &mut [CheckerError] {
         &mut self.errors
     }
 

--- a/src/check/errors.rs
+++ b/src/check/errors.rs
@@ -25,13 +25,13 @@ impl CheckerError {
             text: text,
         }
     }
-    pub fn get_offender(&self) -> &Token {
+    pub fn offender(&self) -> &Token {
         &self.offender
     }
-    pub fn get_references(&self) -> &[Token] {
+    pub fn references(&self) -> &[Token] {
         &self.references
     }
-    pub fn get_text(&self) -> &str {
+    pub fn text(&self) -> &str {
         &self.text
     }
 }

--- a/src/check/tests.rs
+++ b/src/check/tests.rs
@@ -21,7 +21,7 @@ pub fn check(input: &'static str)
         tc.visit_unit(&unit);
         tc.into_results()
     };
-    if !errors.get_errors().is_empty() {
+    if !errors.errors().is_empty() {
         panic!("Got errors running TypeConcretifier: {:#?}", errors);
     }
 

--- a/src/check/types/type_concretifier.rs
+++ b/src/check/types/type_concretifier.rs
@@ -49,7 +49,7 @@ impl<'err, 'builder, 'graph> TypeConcretifier<'err, 'builder, 'graph> {
             Ok((_ix, ty)) => {
                 if let Some(concrete) = self.builder.get_type(&ty) {
                     debug!("Type of {} {:?} => {:?}",
-                        source.get_text(), id, ty);
+                        source.text(), id, ty);
                     self.results.insert(id.clone(), concrete.clone());
                     true
                 }
@@ -103,21 +103,21 @@ impl<'err, 'builder, 'graph> ItemVisitor
     for TypeConcretifier<'err, 'builder, 'graph> {
 
     fn visit_block_fn_decl(&mut self, block_fn: &BlockFnDeclaration) {
-        trace!("Visiting declaration of fn {}", block_fn.get_name());
-        self.infer_var(&block_fn.get_id(), block_fn.get_token(),
-            format!("fn declaration {}", block_fn.get_name()));
+        trace!("Visiting declaration of fn {}", block_fn.name());
+        self.infer_var(&block_fn.id(), block_fn.token(),
+            format!("fn declaration {}", block_fn.name()));
 
-        for &(ref param, ref _param_ty) in block_fn.get_params() {
+        for &(ref param, ref _param_ty) in block_fn.params() {
             trace!("Inferring the type of {} param {}",
-                block_fn.get_name(), param.get_name());
-            self.infer_var(&param.get_id(), param.get_token(),
+                block_fn.name(), param.name());
+            self.infer_var(&param.id(), param.token(),
                 format!("fn {} param {}",
-                    block_fn.get_name(), param.get_name()));
+                    block_fn.name(), param.name()));
         }
 
         // We can't attempt to infer the type of fn params right now because
         // they're not kept in the global scope:
-        self.visit_block(block_fn.get_block());
+        self.visit_block(block_fn.block());
     }
 }
 
@@ -125,20 +125,20 @@ impl<'err, 'builder, 'graph> BlockVisitor
     for TypeConcretifier<'err, 'builder, 'graph> {
 
     fn visit_block(&mut self, block: &Block) {
-        trace!("Visiting block {:?}", block.get_id());
+        trace!("Visiting block {:?}", block.id());
         if block.has_source() {
             trace!("Block {:?} has source {:?}, checking.",
-                block.get_id(), block.get_source());
+                block.id(), block.source());
 
             let context = Token::default();
-            self.infer_var(block.get_source().as_ref().expect("Checked expect"),
+            self.infer_var(block.source().as_ref().expect("Checked expect"),
                 &context,
-                format!("block {:?} source", block.get_id()));
-            self.infer_var(&block.get_id(), &context,
-                format!("block {:?}", block.get_id()));
+                format!("block {:?} source", block.id()));
+            self.infer_var(&block.id(), &context,
+                format!("block {:?}", block.id()));
         }
         else {
-            trace!("Block {:?} has no source", block.get_id());
+            trace!("Block {:?} has no source", block.id());
         }
 
         visit::walk_block(self, block);
@@ -172,8 +172,8 @@ impl<'err, 'builder, 'graph> ExpressionVisitor
     }
 
     fn visit_var_ref(&mut self, ident: &Identifier) {
-        self.infer_var(&ident.get_id(), ident.get_token(),
-            format!("Variable {}", ident.get_name()));
+        self.infer_var(&ident.id(), ident.token(),
+            format!("Variable {}", ident.name()));
     }
 
     fn visit_if_expr(&mut self, if_expr: &IfExpression) {
@@ -189,24 +189,24 @@ impl<'err, 'builder, 'graph> ExpressionVisitor
     }
 
     fn visit_fn_call(&mut self, fn_call: &FnCall) {
-        self.infer_var(&fn_call.get_id(), fn_call.get_token(),
-            format!("Call to {}", fn_call.get_text()));
-        for arg in fn_call.get_args() {
-            self.visit_expression(arg.get_expression());
+        self.infer_var(&fn_call.id(), fn_call.token(),
+            format!("Call to {}", fn_call.text()));
+        for arg in fn_call.args() {
+            self.visit_expression(arg.expression());
         }
     }
 
     fn visit_assignment(&mut self, assign: &Assignment) {
-        self.visit_expression(assign.get_rvalue());
-        self.infer_var(&assign.get_lvalue().get_id(),
-            assign.get_lvalue().get_token(),
+        self.visit_expression(assign.rvalue());
+        self.infer_var(&assign.lvalue().id(),
+            assign.lvalue().token(),
             format!("assignment to {}",
-                    assign.get_lvalue().get_name()));
+                    assign.lvalue().name()));
     }
 
     fn visit_declaration(&mut self, decl: &Declaration) {
-        self.visit_expression(decl.get_value());
-        self.infer_var(&decl.get_id(), decl.get_token(),
-            format!("definition of variable {}", decl.get_token()));
+        self.visit_expression(decl.value());
+        self.infer_var(&decl.id(), decl.token(),
+            format!("definition of variable {}", decl.token()));
     }
 }

--- a/src/compile/module_compiler.rs
+++ b/src/compile/module_compiler.rs
@@ -50,7 +50,7 @@ impl<'ctx, 'b, M: ModuleProvider<'ctx>> ModuleCompiler<'ctx, 'b, M> {
     }
 
     fn current_module(&self) -> &Module<'ctx> {
-        self.module_provider.get_module()
+        self.module_provider.module()
     }
 
     fn llvm_type_of(&self, id: &ScopedId) -> Type<'ctx> {
@@ -63,7 +63,7 @@ impl<'ctx, 'b, M: ModuleProvider<'ctx>> ModuleCompiler<'ctx, 'b, M> {
     fn llvm_type_of_concrete(&self, concrete: &ConcreteType) -> Type<'ctx> {
         match concrete {
             &ConcreteType::Named(ref name) => {
-                match name.get_name() {
+                match name.name() {
                     "()" => Type::void(&self.context),
                     "bool" => Type::int1(&self.context),
                     "float" => Type::double(&self.context),
@@ -72,11 +72,11 @@ impl<'ctx, 'b, M: ModuleProvider<'ctx>> ModuleCompiler<'ctx, 'b, M> {
             },
             &ConcreteType::Function(ref fn_ty) => {
                 let mut params = Vec::new();
-                for &(ref _name, ref param_ty) in fn_ty.get_params() {
+                for &(ref _name, ref param_ty) in fn_ty.params() {
                     params.push(self.llvm_type_of_concrete(param_ty));
                 }
                 Type::function(
-                    &self.llvm_type_of_concrete(fn_ty.get_return_ty()),
+                    &self.llvm_type_of_concrete(fn_ty.return_ty()),
                     params, false)
             }
         }
@@ -102,22 +102,22 @@ impl<'ctx, 'b, M> ItemVisitor for ModuleCompiler<'ctx, 'b, M>
     where M: ModuleProvider<'ctx>, 'ctx: 'b {
 
     fn visit_block_fn_decl(&mut self, block_fn: &BlockFnDeclaration) {
-        trace!("Checking declaration of {}", block_fn.get_name());
+        trace!("Checking declaration of {}", block_fn.name());
 
-        let fn_type = self.llvm_type_of(&block_fn.get_id());
+        let fn_type = self.llvm_type_of(&block_fn.id());
         let fn_ref = self.current_module().add_function(
-            block_fn.get_name(), &fn_type);
+            block_fn.name(), &fn_type);
 
         // Gotta insert the fn ref first so it can be called recursively
-        self.scope_manager.insert(block_fn.get_id().clone(), fn_ref.clone());
+        self.scope_manager.insert(block_fn.id().clone(), fn_ref.clone());
         trace!("Inserted {} into the scope manager",
-            block_fn.get_name());
+            block_fn.name());
 
         // Gonna be fancy and have a separate basic block for parameters
         let entry_block = self.context.append_basic_block(&fn_ref, "entry");
         let start_block = self.context.append_basic_block(&fn_ref, "start");
         self.builder.position_at_end(&entry_block);
-        trace!("Ready to build {}", block_fn.get_name());
+        trace!("Ready to build {}", block_fn.name());
 
         let fn_params = fn_ref.get_params();
         trace!("fn has {} params", fn_params.len());
@@ -126,15 +126,15 @@ impl<'ctx, 'b, M> ItemVisitor for ModuleCompiler<'ctx, 'b, M>
         // function values there. This allows LLVM to mutate function params
         // even if we don't allow it right now.
         for (&(ref ast_param, _), ref ir_param) in
-                        block_fn.get_params().iter().zip(fn_ref.get_params()) {
+                        block_fn.params().iter().zip(fn_ref.get_params()) {
             trace!("Adding fn param {} (ix {:?})",
-                ast_param.get_name(), ast_param.get_id());
-            ir_param.set_name(ast_param.get_name());
-            let param_type = self.llvm_type_of(&ast_param.get_id());
+                ast_param.name(), ast_param.id());
+            ir_param.set_name(ast_param.name());
+            let param_type = self.llvm_type_of(&ast_param.id());
             let alloca = self.builder
-                .build_alloca(&param_type, ast_param.get_name());
+                .build_alloca(&param_type, ast_param.name());
             self.builder.build_store(&ir_param, &alloca);
-            self.scope_manager.insert(ast_param.get_id().clone(), alloca);
+            self.scope_manager.insert(ast_param.id().clone(), alloca);
         }
         self.builder.build_br(&start_block);
         self.builder.position_at_end(&start_block);
@@ -142,7 +142,7 @@ impl<'ctx, 'b, M> ItemVisitor for ModuleCompiler<'ctx, 'b, M>
         trace!("Moving to check the block");
 
         // Compile the function
-        self.visit_block(&block_fn.get_block());
+        self.visit_block(&block_fn.block());
 
         if let Some(remaining_expr) = self.ir_code.pop() {
             trace!("Found final expression, appending a return");
@@ -152,8 +152,8 @@ impl<'ctx, 'b, M> ItemVisitor for ModuleCompiler<'ctx, 'b, M>
         assert!(fn_ref.verify(
             LLVMVerifierFailureAction::LLVMPrintMessageAction));
         if self.optimizations {
-            trace!("Running optimizations on fn {}", block_fn.get_name());
-            self.module_provider.get_pass_manager().run(&fn_ref);
+            trace!("Running optimizations on fn {}", block_fn.name());
+            self.module_provider.pass_manager().run(&fn_ref);
         }
     }
 }
@@ -169,7 +169,7 @@ impl<'ctx, 'b, M> BlockVisitor for ModuleCompiler<'ctx, 'b, M>
         visit::walk_block(self, block);
         if block.has_source() {
             trace!("Block has source, setting ID");
-            self.current_type = self.llvm_type_of(&block.get_id());
+            self.current_type = self.llvm_type_of(&block.id());
         }
     }
 }
@@ -185,7 +185,7 @@ impl<'ctx, 'b, M> StatementVisitor for ModuleCompiler<'ctx, 'b, M>
     fn visit_if_block(&mut self, if_block: &IfBlock) {
         trace!("Checking if block");
         // Create some lists of values to use later
-        let condition_count = if_block.get_conditionals().len();
+        let condition_count = if_block.conditionals().len();
         let valued_if = if_block.has_source();
         let function = self.builder.insert_block().get_parent()
             .expect("Just inserted a block");
@@ -196,7 +196,7 @@ impl<'ctx, 'b, M> StatementVisitor for ModuleCompiler<'ctx, 'b, M>
 
         trace!("Preparing to emit {} conditionals", condition_count);
         // Populate a list of the future blocks to have
-        for (ix, _conditional) in if_block.get_conditionals().iter().enumerate() {
+        for (ix, _conditional) in if_block.conditionals().iter().enumerate() {
             trace!("Creating condition block {}", ix);
             // We skip adding the first one to this list because we know we
             // will have at least one later so we handle it separately.
@@ -227,9 +227,9 @@ impl<'ctx, 'b, M> StatementVisitor for ModuleCompiler<'ctx, 'b, M>
                                                                      "if_end"));
 
         let mut ix = 0;
-        for conditional in if_block.get_conditionals() {
+        for conditional in if_block.conditionals() {
             trace!("Checking expr for condition {}", ix);
-            self.visit_expression(conditional.get_condition());
+            self.visit_expression(conditional.condition());
             let cond_value = self.ir_code.pop()
                 .expect("Did not get IR value from if block condition");
             let cond_cmp_name = format!("if_{}_cmp", ix);
@@ -246,7 +246,7 @@ impl<'ctx, 'b, M> StatementVisitor for ModuleCompiler<'ctx, 'b, M>
             trace!("Positioning at end of cond block {}", ix);
             self.builder.position_at_end(&condition_blocks[ix]);
             trace!("Checking conditional block");
-            self.visit_block(conditional.get_block());
+            self.visit_block(conditional.block());
             // If this is a valued if, save the value ref for this branch of the condition
             if valued_if {
                 let value = self.ir_code.pop()
@@ -267,7 +267,7 @@ impl<'ctx, 'b, M> StatementVisitor for ModuleCompiler<'ctx, 'b, M>
 
         trace!("Finished checking conditions");
         // If there's an else, check that too
-        if let Some(&(_, ref else_block)) = if_block.get_else() {
+        if let Some(&(_, ref else_block)) = if_block.else_block() {
             trace!("Checking else block");
             self.visit_block(else_block);
             if valued_if {
@@ -296,7 +296,7 @@ impl<'ctx, 'b, M> StatementVisitor for ModuleCompiler<'ctx, 'b, M>
                 .expect("No condition blocks"));
             trace!("Generating phi node with {} values and {} edges",
                 incoming_values.len(), incoming_conditions.len());
-            let phi_type = self.llvm_type_of(&if_block.get_id());
+            let phi_type = self.llvm_type_of(&if_block.id());
             let phi = self.builder.build_phi(&phi_type, "if_phi");
             phi.add_incoming(incoming_values, incoming_conditions);
             self.ir_code.push(phi);
@@ -306,7 +306,7 @@ impl<'ctx, 'b, M> StatementVisitor for ModuleCompiler<'ctx, 'b, M>
 
     fn visit_return_stmt(&mut self, return_: &Return) {
         trace!("Checking return statement");
-        if let Some(ref return_expr) = return_.get_value() {
+        if let Some(ref return_expr) = return_.value() {
             self.visit_expression(return_expr);
             let return_val = self.ir_code.pop()
                 .expect("Could not generate value of return");
@@ -328,8 +328,8 @@ impl<'ctx, 'b, M> ExpressionVisitor for ModuleCompiler<'ctx, 'b, M>
 
     fn visit_literal_expr(&mut self, literal: &Literal) {
         use ast::LiteralValue;
-        trace!("Checking literal {}", literal.get_token().get_text());
-        let (literal_value, literal_type) = match literal.get_value() {
+        trace!("Checking literal {}", literal.token().text());
+        let (literal_value, literal_type) = match literal.value() {
             &LiteralValue::Bool(b) => {
                 let bool_value = if b { 1u64 } else { 0u64 };
                 (Type::int1(&self.context)
@@ -352,36 +352,36 @@ impl<'ctx, 'b, M> ExpressionVisitor for ModuleCompiler<'ctx, 'b, M>
 
     fn visit_var_ref(&mut self, ident_ref: &Identifier) {
         trace!("Checking variable ref {} ({:?})",
-            ident_ref.get_name(), ident_ref.get_id());
-        let var_alloca = self.scope_manager.get(&ident_ref.get_id())
+            ident_ref.name(), ident_ref.id());
+        let var_alloca = self.scope_manager.get(&ident_ref.id())
             .expect("Attempted to check var ref but had no alloca for it")
             .clone();
-        let load_name = format!("load_{}", ident_ref.get_name());
+        let load_name = format!("load_{}", ident_ref.name());
         trace!("Creating {}", load_name);
         let builder = self.builder;
         let var_load = builder.build_load(&var_alloca, &load_name);
-        self.current_type = self.llvm_type_of(&ident_ref.get_id());
+        self.current_type = self.llvm_type_of(&ident_ref.id());
         self.ir_code.push(var_load);
     }
 
 
     fn visit_declaration(&mut self, decl: &Declaration) {
-        trace!("Checking declaration for {}", decl.get_name());
-        self.visit_expression(decl.get_value());
+        trace!("Checking declaration for {}", decl.name());
+        self.visit_expression(decl.value());
         let decl_value = self.ir_code.pop()
             .expect("Did not have rvalue of declaration");
         let builder = self.builder;
-        let alloca = builder.build_alloca(&self.current_type, decl.get_name());
+        let alloca = builder.build_alloca(&self.current_type, decl.name());
         builder.build_store(&decl_value, &alloca);
-        self.scope_manager.insert(decl.get_id().clone(), alloca);
+        self.scope_manager.insert(decl.id().clone(), alloca);
     }
 
     fn visit_assignment(&mut self, assign: &Assignment) {
-        trace!("Checking assignment of {}", assign.get_lvalue().get_name());
-        self.visit_expression(assign.get_rvalue());
+        trace!("Checking assignment of {}", assign.lvalue().name());
+        self.visit_expression(assign.rvalue());
         let rvalue = self.ir_code.pop()
             .expect("Could not generate rvalue of assignment");
-        let var_alloca = self.scope_manager.get(&assign.get_lvalue().get_id())
+        let var_alloca = self.scope_manager.get(&assign.lvalue().id())
             .expect("Could not find existing var for assignment!")
             .clone();
         let builder = self.builder;
@@ -389,13 +389,13 @@ impl<'ctx, 'b, M> ExpressionVisitor for ModuleCompiler<'ctx, 'b, M>
     }
 
     fn visit_unary_op(&mut self, unary_op: &UnaryOperation) {
-        debug_assert!(unary_op.get_operator() == Operator::Subtraction,
-            "Invalid unary operator {:?}", unary_op.get_operator());
-        self.visit_expression(unary_op.get_inner());
+        debug_assert!(unary_op.operator() == Operator::Subtraction,
+            "Invalid unary operator {:?}", unary_op.operator());
+        self.visit_expression(unary_op.inner());
         let inner_value = self.ir_code.pop()
             .expect("Did not generate value inside unary op");
         let builder = self.builder;
-        let (value, type_) = match unary_op.get_operator() {
+        let (value, type_) = match unary_op.operator() {
             Operator::Subtraction =>
                 (builder.build_neg(&inner_value, "negate"),
                 Type::double(&self.context)),
@@ -406,19 +406,19 @@ impl<'ctx, 'b, M> ExpressionVisitor for ModuleCompiler<'ctx, 'b, M>
     }
 
     fn visit_binary_op(&mut self, binary_op: &BinaryOperation) {
-        trace!("Checking binary operation {:?}", binary_op.get_operator());
-        trace!("Checking {:?} lvalue", binary_op.get_operator());
-        self.visit_expression(binary_op.get_left());
+        trace!("Checking binary operation {:?}", binary_op.operator());
+        trace!("Checking {:?} lvalue", binary_op.operator());
+        self.visit_expression(binary_op.left());
         let left_register = self.ir_code.pop()
             .expect("Could not generate lvalue of binary op");
-        trace!("Checking {:?} rvalue", binary_op.get_operator());
-        self.visit_expression(binary_op.get_right());
+        trace!("Checking {:?} rvalue", binary_op.operator());
+        self.visit_expression(binary_op.right());
         let right_register = self.ir_code.pop()
             .expect("Could not generate rvalue of binary op");
         let builder = self.builder;
         trace!("Appending binary operation");
         use llvm_sys::LLVMRealPredicate::*;
-        let (bin_op_value, bin_op_type) = match binary_op.get_operator() {
+        let (bin_op_value, bin_op_type) = match binary_op.operator() {
             Operator::Addition => {
                 (builder.build_fadd(&left_register, &right_register, "add"),
                 Type::double(&self.context))
@@ -483,20 +483,20 @@ impl<'ctx, 'b, M> ExpressionVisitor for ModuleCompiler<'ctx, 'b, M>
     }
 
     fn visit_fn_call(&mut self, fn_call: &FnCall) {
-        trace!("Checking call to {}", fn_call.get_text());
-        let fn_type = match self.types[&fn_call.get_id()].clone() {
+        trace!("Checking call to {}", fn_call.text());
+        let fn_type = match self.types[&fn_call.id()].clone() {
             ConcreteType::Function(fn_type) => fn_type,
             _other => panic!("Function call's ident had non-fn type")
         };
 
         trace!("Found function type {:?}", fn_type);
 
-        let mut arg_values = Vec::with_capacity(fn_call.get_args().len());
+        let mut arg_values = Vec::with_capacity(fn_call.args().len());
 
-        for (_ix, &(ref name, _)) in fn_type.get_params().iter().enumerate() {
-            for arg in fn_call.get_args() {
-                if arg.get_name().get_name() == name {
-                    self.visit_expression(arg.get_expression());
+        for (_ix, &(ref name, _)) in fn_type.params().iter().enumerate() {
+            for arg in fn_call.args() {
+                if arg.name().name() == name {
+                    self.visit_expression(arg.expression());
                     arg_values.push(self.ir_code.pop()
                         .expect("Could not get alloca for named var of fn arg"));
                     break
@@ -504,17 +504,17 @@ impl<'ctx, 'b, M> ExpressionVisitor for ModuleCompiler<'ctx, 'b, M>
             }
         }
 
-        let name = format!("call_{}", fn_call.get_text());
-        let fn_ref = &self.scope_manager[&fn_call.get_id()];
+        let name = format!("call_{}", fn_call.text());
+        let fn_ref = &self.scope_manager[&fn_call.id()];
         trace!("Got a function ref to call");
         let call = self.builder.build_call(fn_ref, arg_values, &name);
-        self.current_type = self.llvm_type_of_concrete(fn_type.get_return_ty());
+        self.current_type = self.llvm_type_of_concrete(fn_type.return_ty());
         self.ir_code.push(call);
     }
 
     fn visit_if_expr(&mut self, if_expr: &IfExpression) {
         // Build conditional expr
-        self.visit_expression(if_expr.get_condition());
+        self.visit_expression(if_expr.condition());
         let condition_expr = self.ir_code.pop()
             .expect("Did not get value from if conditional");
         let bool_type = Type::int1(&self.context);
@@ -536,7 +536,7 @@ impl<'ctx, 'b, M> ExpressionVisitor for ModuleCompiler<'ctx, 'b, M>
 
         // Emit the then code
         self.builder.position_at_end(&then_block);
-        self.visit_expression(if_expr.get_true_expr());
+        self.visit_expression(if_expr.true_expr());
         let then_value = self.ir_code.pop()
             .expect("Did not get IR value from visiting `then` clause of if expression");
         self.builder.build_br(&end_block);
@@ -544,7 +544,7 @@ impl<'ctx, 'b, M> ExpressionVisitor for ModuleCompiler<'ctx, 'b, M>
 
         // Emit the else code
         self.builder.position_at_end(&else_block);
-        self.visit_expression(if_expr.get_else()); // self.current_type set
+        self.visit_expression(if_expr.else_expr()); // self.current_type set
         let else_value = self.ir_code.pop()
             .expect("Did not get IR value from visiting `else` clause of if expression");
         self.builder.build_br(&end_block);

--- a/src/compile/module_provider.rs
+++ b/src/compile/module_provider.rs
@@ -1,8 +1,8 @@
 use llvm::{Module, FunctionPassManager};
 
 pub trait ModuleProvider<'ctx> {
-    fn get_module(&self) -> &Module<'ctx>;
-    fn get_pass_manager(&mut self) -> &FunctionPassManager;
+    fn module(&self) -> &Module<'ctx>;
+    fn pass_manager(&mut self) -> &FunctionPassManager;
 }
 
 pub struct SimpleModuleProvider<'ctx> {
@@ -28,10 +28,10 @@ impl<'ctx> SimpleModuleProvider<'ctx> {
 }
 
 impl<'ctx> ModuleProvider<'ctx> for SimpleModuleProvider<'ctx> {
-    fn get_module(&self) -> &Module<'ctx> {
+    fn module(&self) -> &Module<'ctx> {
         &self.module
     }
-    fn get_pass_manager(&mut self) -> &FunctionPassManager {
+    fn pass_manager(&mut self) -> &FunctionPassManager {
         &mut self.fn_pass_manager
     }
 }

--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -52,6 +52,6 @@ fn compile_example() {
                 "FACT_HELPER",
                 &context);
 
-        module_provider.get_module().dump();
+        module_provider.module().dump();
     }
 }

--- a/src/identify/concrete_type.rs
+++ b/src/identify/concrete_type.rs
@@ -32,7 +32,7 @@ impl NamedType {
         NamedType { name }
     }
 
-    pub fn get_name(&self) -> &str {
+    pub fn name(&self) -> &str {
         &self.name
     }
 }
@@ -48,10 +48,10 @@ impl FnType {
     pub fn new(args: Vec<(String, ConcreteType)>, ret: ConcreteType) -> FnType {
         FnType { args, ret: Box::new(ret) }
     }
-    pub fn get_params(&self) -> &[(String, ConcreteType)] {
+    pub fn params(&self) -> &[(String, ConcreteType)] {
         &self.args
     }
-    pub fn get_return_ty(&self) -> &ConcreteType {
+    pub fn return_ty(&self) -> &ConcreteType {
         &*self.ret
     }
 }

--- a/src/identify/mod.rs
+++ b/src/identify/mod.rs
@@ -32,11 +32,11 @@
 //!
 //! # Invariants from this pass
 //!
-//! - Calling `.get_id()` on an `Identifier` in the `AST` should yield a valid
+//! - Calling `.id()` on an `Identifier` in the `AST` should yield a valid
 //! (non-default) `ScopedId` if the `Identifier` is being used in valid code.
 //! This applies to identifiers used for variables in expressions _and_ for
 //! identifiers used in type expressions.
-//! - Getting a default `ScopedId` from a call to `get_id()` is an indication of
+//! - Getting a default `ScopedId` from a call to `id()` is an indication of
 //! a variable or type not being defined or possibly being defined twice.
 //!
 //! In the future errors will be held in a `ScopeErrorMap` structure.

--- a/src/identify/names/item_namer.rs
+++ b/src/identify/names/item_namer.rs
@@ -45,24 +45,24 @@ impl<'err, 'builder> UnitVisitor for ItemVarIdentifier<'err, 'builder> {
 
 impl<'err, 'builder> ItemVisitor for ItemVarIdentifier<'err, 'builder> {
     fn visit_block_fn_decl(&mut self, block_fn: &BlockFnDeclaration) {
-        trace!("Visiting fn definition {}", block_fn.get_name());
-        if let Some(_previous_def_id) = self.builder.get(block_fn.get_name()) {
+        trace!("Visiting fn definition {}", block_fn.name());
+        if let Some(_previous_def_id) = self.builder.get(block_fn.name()) {
             // fn has been previously defined
-            debug!("Emitting error: {} already declared", block_fn.get_name());
+            debug!("Emitting error: {} already declared", block_fn.name());
             self.errors.add_error(CheckerError::new(
-                block_fn.get_token().clone(),
+                block_fn.token().clone(),
                 vec![],
-                format!("Function {} is already declared", block_fn.get_name())
+                format!("Function {} is already declared", block_fn.name())
             ));
             return
         }
         // If it was not in the builder its ID should be default.
-        debug_assert!(block_fn.get_ident().get_id().is_default(),
+        debug_assert!(block_fn.ident().id().is_default(),
             "Block fn {:?} already had an ID", block_fn);
 
         let fn_id = self.current_id.clone();
-        trace!("Created id {:?} for block fn {}", fn_id, block_fn.get_name());
-        self.builder.define_local(block_fn.get_name().to_string(),
+        trace!("Created id {:?} for block fn {}", fn_id, block_fn.name());
+        self.builder.define_local(block_fn.name().to_string(),
                                   fn_id.clone());
         block_fn.set_id(fn_id);
 
@@ -76,28 +76,28 @@ impl<'err, 'builder> ItemVisitor for ItemVarIdentifier<'err, 'builder> {
 
         // https://github.com/immington-industries/protosnirk/issues/50
 
-        for &(ref param, ref _param_type) in block_fn.get_params() {
-            let param_name = param.get_name();
+        for &(ref param, ref _param_type) in block_fn.params() {
+            let param_name = param.name();
             if let Some(_previous_def_id) = self.builder.get(param_name) {
                 debug!("Emitting error: {} in {} already declared",
-                    param_name, block_fn.get_name());
+                    param_name, block_fn.name());
                 let error_text = format!(
                     "Parameter {} of function {} is already declared",
-                    param.get_name(), block_fn.get_name());
+                    param.name(), block_fn.name());
                 self.errors.add_error(CheckerError::new(
-                    block_fn.get_token().clone(), vec![], error_text
+                    block_fn.token().clone(), vec![], error_text
                 ));
                 return // Stop checking params if there's a dupe.
             }
 
             trace!("Created id {:?} for {} param {}",
-                self.current_id, block_fn.get_name(), param.get_name());
+                self.current_id, block_fn.name(), param.name());
             self.builder.define_local(param_name.to_string(),
                                       self.current_id.clone());
             // We also put the param in the global scope as this is the only
             // scope visible outside the visitor.
             self.builder.define_global(
-                    format!("{}::{}", block_fn.get_name(), param_name),
+                    format!("{}::{}", block_fn.name(), param_name),
                     self.current_id.clone());
             param.set_id(self.current_id.clone());
 

--- a/src/identify/scope_builder.rs
+++ b/src/identify/scope_builder.rs
@@ -95,7 +95,7 @@ impl<T: Debug + Hash + Eq> ScopeBuilder<T> {
     }
 
     /// Get a variable defined in local scopeh
-    pub fn get_local<K: Borrow<T> + Debug>(&self, key: &K)
+    pub fn local<K: Borrow<T> + Debug>(&self, key: &K)
                                            -> Option<&ScopedId> {
         debug_assert!(!self.scopes.is_empty(),
             "Attempted to get local var {:?} with no scopes", key);
@@ -104,7 +104,7 @@ impl<T: Debug + Hash + Eq> ScopeBuilder<T> {
     }
 
     /// Get a variable, starting from the given scope
-    pub fn get_in_scope<K>(&self, key: &K, scope_level: usize)
+    pub fn in_scope<K>(&self, key: &K, scope_level: usize)
                            -> Option<&ScopedId> where K: Borrow<T> + Debug {
         debug_assert!(self.scopes.len() >= scope_level,
             "Do not have {} scopes to search, only have {}",

--- a/src/identify/tests.rs
+++ b/src/identify/tests.rs
@@ -20,18 +20,18 @@ pub fn identify(input: &'static str)
     info!("Running ASTIdentifer");
     ASTIdentifier::new(&mut name_builder, &mut type_builder, &mut errors)
         .visit_unit(&unit);
-    if !errors.get_errors().is_empty() {
-        panic!("Got errors running ASTIdentifier: {:?}", errors.get_errors());
+    if !errors.errors().is_empty() {
+        panic!("Got errors running ASTIdentifier: {:?}", errors.errors());
     }
     debug!("Running ASTTypeChecker");
     ASTTypeChecker::new(&mut type_builder, &mut errors, &mut graph)
                    .visit_unit(&unit);
-    if !errors.get_errors().is_empty() {
-        panic!("Got errors running ASTTypeChecker: {:?}", errors.get_errors());
+    if !errors.errors().is_empty() {
+        panic!("Got errors running ASTTypeChecker: {:?}", errors.errors());
     }
 
-    assert!(errors.get_errors().is_empty(),
-        "Errors during identification: {:?}", errors.get_errors());
+    assert!(errors.errors().is_empty(),
+        "Errors during identification: {:?}", errors.errors());
 
     return (unit, errors, name_builder, type_builder, graph);
 }

--- a/src/identify/type_scope_builder.rs
+++ b/src/identify/type_scope_builder.rs
@@ -45,11 +45,11 @@ impl TypeScopeBuilder {
         self.types.get(id)
     }
 
-    pub fn get_named_type_id(&self, name: &str) -> Option<&ScopedId> {
+    pub fn named_type_id(&self, name: &str) -> Option<&ScopedId> {
         self.names.get(name)
     }
 
-    pub fn get_named_type(&self, name: &str) -> Option<&ConcreteType> {
+    pub fn named_type(&self, name: &str) -> Option<&ConcreteType> {
         self.names.get(name).and_then(|id| self.types.get(id))
     }
 

--- a/src/identify/types/expr_namer.rs
+++ b/src/identify/types/expr_namer.rs
@@ -31,11 +31,11 @@ impl<'err, 'builder> UnitVisitor for ExprTypeIdentifier<'err, 'builder> {
 
 impl<'err, 'builder> ItemVisitor for ExprTypeIdentifier<'err, 'builder> {
     fn visit_block_fn_decl(&mut self, block_fn: &BlockFnDeclaration) {
-        if block_fn.get_id().is_default() {
-            trace!("Skipping unidentified block fn {}", block_fn.get_name());
+        if block_fn.id().is_default() {
+            trace!("Skipping unidentified block fn {}", block_fn.name());
             return
         }
-        self.visit_block(block_fn.get_block());
+        self.visit_block(block_fn.block());
     }
 }
 
@@ -89,17 +89,17 @@ impl<'err, 'builder> ExpressionVisitor
 
     fn visit_fn_call(&mut self, fn_call: &FnCall) {
         // Technically shouldn't be allowed, but see #30 above.
-        for arg in fn_call.get_args() {
-            self.visit_expression(arg.get_expression());
+        for arg in fn_call.args() {
+            self.visit_expression(arg.expression());
         }
     }
 
     fn visit_assignment(&mut self, assign: &Assignment) {
-        self.visit_expression(assign.get_rvalue());
+        self.visit_expression(assign.rvalue());
     }
 
     fn visit_declaration(&mut self, declaration: &Declaration) {
-        if let Some(ref decl_ty) = declaration.get_type_decl() {
+        if let Some(ref decl_ty) = declaration.type_decl() {
             // visit the declaration
             TypeIdentifier::new(self.errors, self.builder)
                           .visit_type_expr(decl_ty);

--- a/src/identify/types/inference_source.rs
+++ b/src/identify/types/inference_source.rs
@@ -52,28 +52,28 @@ impl fmt::Debug for InferenceSource {
         use self::InferenceSource::*;
         match *self {
             FnSignature(ref id) => f.debug_tuple("IsTheFn")
-                                 .field(&id.get_name())
+                                 .field(&id.name())
                                  .finish(),
             FnReturnType(ref id) => f.debug_tuple("FnReturn")
-                                  .field(&id.get_name())
+                                  .field(&id.name())
                                   .finish(),
             FnParameter(ref id) => f.debug_tuple("FnParam")
-                                 .field(&id.get_name())
+                                 .field(&id.name())
                                  .finish(),
             CallArgument(ref id) => f.debug_tuple("CallArg")
-                                  .field(&id.get_name())
+                                  .field(&id.name())
                                   .finish(),
             CallReturnType(ref id) => f.debug_tuple("CallReturn")
-                                    .field(&id.get_name())
+                                    .field(&id.name())
                                     .finish(),
             ExplicitDecl(ref id) => f.debug_tuple("ExplicitLet")
-                                  .field(&id.get_name())
+                                  .field(&id.name())
                                   .finish(),
             Declaration(ref id) => f.debug_tuple("Let")
-                                 .field(&id.get_name())
+                                 .field(&id.name())
                                  .finish(),
             LiteralValue(ref lit) => f.debug_tuple("Literal")
-                                   .field(&lit.get_value())
+                                   .field(&lit.value())
                                    .finish(),
             IfConditionalBool => f.write_str("IfCond"),
             IfBranchesSame => f.write_str("IfBranchEq"),

--- a/src/identify/types/item_namer.rs
+++ b/src/identify/types/item_namer.rs
@@ -31,38 +31,38 @@ impl<'err, 'builder> UnitVisitor for ItemTypeIdentifier<'err, 'builder> {
 impl<'err, 'builder> ItemVisitor for ItemTypeIdentifier<'err, 'builder> {
     fn visit_block_fn_decl(&mut self, fn_decl: &BlockFnDeclaration) {
         trace!("Visiting block fn declaration");
-        if fn_decl.get_id().is_default() {
-            debug!("Skipping fn {} with default ID", fn_decl.get_name());
+        if fn_decl.id().is_default() {
+            debug!("Skipping fn {} with default ID", fn_decl.name());
             return
         }
 
         // Declared functions' types are handled here because we do not want
         // to run full type inference at the item level.
-        let mut arg_types = Vec::with_capacity(fn_decl.get_params().len());
+        let mut arg_types = Vec::with_capacity(fn_decl.params().len());
 
-        for &(ref param_ident, ref param_ty_expr) in fn_decl.get_params() {
+        for &(ref param_ident, ref param_ty_expr) in fn_decl.params() {
             TypeIdentifier::new(self.errors, self.builder)
                            .visit_type_expr(param_ty_expr);
             // Stop if we can't idenify a parameter type.
-            if param_ty_expr.get_id().is_default() {
+            if param_ty_expr.id().is_default() {
                 return
             }
-            let param_ty = self.builder.get_type(&param_ty_expr.get_id())
+            let param_ty = self.builder.get_type(&param_ty_expr.id())
                 .expect("TypeIdentifier did not update param's type ID");
-            arg_types.push((param_ident.get_name().to_string(),
+            arg_types.push((param_ident.name().to_string(),
                             param_ty.clone()));
         }
-        let return_ty = fn_decl.get_return_type();
+        let return_ty = fn_decl.return_type();
         TypeIdentifier::new(self.errors, self.builder)
                        .visit_type_expr(return_ty);
 
-        if return_ty.get_id().is_default() { return }
-        let ret_ty = self.builder.get_type(&return_ty.get_id())
+        if return_ty.id().is_default() { return }
+        let ret_ty = self.builder.get_type(&return_ty.id())
             .expect("TypeIdentifier did not update param's type ID")
             .clone();
 
         let fn_concrete = ConcreteType::Function(
             FnType::new(arg_types, ret_ty));
-        self.builder.add_type(fn_decl.get_id().clone(), fn_concrete);
+        self.builder.add_type(fn_decl.id().clone(), fn_concrete);
     }
 }

--- a/src/identify/types/item_typographer.rs
+++ b/src/identify/types/item_typographer.rs
@@ -35,21 +35,21 @@ impl<'builder, 'err, 'graph> ItemVisitor
     for ItemTypographer<'builder, 'err, 'graph> {
 
     fn visit_block_fn_decl(&mut self, block_fn: &BlockFnDeclaration) {
-        trace!("Visiting block fn {}", block_fn.get_name());
-        let fn_scope_id = block_fn.get_ident().get_id();
+        trace!("Visiting block fn {}", block_fn.name());
+        let fn_scope_id = block_fn.ident().id();
         if fn_scope_id.is_default() {
-            debug!("Ignoring unnamed fn {}", block_fn.get_name());
+            debug!("Ignoring unnamed fn {}", block_fn.name());
             return
         }
 
         match self.builder.get_type(&fn_scope_id) {
             Some(_ty) => {
                 trace!("Adding type of fn {} to graph",
-                    block_fn.get_name());
+                    block_fn.name());
                 self.graph.add_type(fn_scope_id.clone())
             }
             None => {
-                debug!("Ignoring unknown type fn {}", block_fn.get_name());
+                debug!("Ignoring unknown type fn {}", block_fn.name());
                 return
             }
         };
@@ -66,35 +66,35 @@ impl<'builder, 'err, 'graph> ItemVisitor
         // This check is done during this phase because the identify phase
         // does not have the type graph.
 
-        for &(ref param_ident, ref param_ty_expr) in block_fn.get_params() {
+        for &(ref param_ident, ref param_ty_expr) in block_fn.params() {
             trace!("Checking fn {} param {}",
-                block_fn.get_name(), param_ident.get_name());
+                block_fn.name(), param_ident.name());
             // t_param = t_param_expr
 
-            let param_ty_id = param_ty_expr.get_id();
+            let param_ty_id = param_ty_expr.id();
             // Stop if identify phase did not identify parameter type
             if param_ty_id.is_default() {
                 debug!("Ignoring fn {}, unknown type of param {}",
-                    block_fn.get_name(), param_ident.get_name());
+                    block_fn.name(), param_ident.name());
                 return
             }
 
-            let param_var_id = param_ident.get_id();
+            let param_var_id = param_ident.id();
             if param_var_id.is_default() {
                 debug!("Ignoring fn {}, unknown param {}",
-                    block_fn.get_name(), param_ident.get_name());
+                    block_fn.name(), param_ident.name());
                 return
             }
 
             let param_ty_ix = match self.builder.get_type(&param_ty_id) {
                 Some(_ty) => {
                     trace!("Ensuring type of fn {} param {} in graph",
-                        block_fn.get_name(), param_ident.get_name());
+                        block_fn.name(), param_ident.name());
                     self.graph.add_type(param_ty_id.clone())
                 },
                 None => {
                     debug!("Ignoring fn {}, unknown type of param {}",
-                        block_fn.get_name(), param_ident.get_name());
+                        block_fn.name(), param_ident.name());
                     return
                 }
             };
@@ -102,7 +102,7 @@ impl<'builder, 'err, 'graph> ItemVisitor
             let param_var_ix = self.graph.add_variable(param_var_id.clone());
 
             self.graph.add_inference(param_var_ix, param_ty_ix,
-                InferenceSource::FnParameter(block_fn.get_ident().clone()));
+                InferenceSource::FnParameter(block_fn.ident().clone()));
         }
 
         // Don't need to explicitly add the return type to the graph.

--- a/src/identify/types/type_graph.rs
+++ b/src/identify/types/type_graph.rs
@@ -79,7 +79,7 @@ impl TypeGraph {
         self.types.get(ty).cloned()
     }
 
-    pub fn get_variable(&self, var: &ScopedId) -> Option<NodeIndex> {
+    pub fn variable(&self, var: &ScopedId) -> Option<NodeIndex> {
         self.variables.get(var).cloned()
     }
 

--- a/src/identify/types/type_identifier.rs
+++ b/src/identify/types/type_identifier.rs
@@ -27,15 +27,15 @@ impl<'err, 'builder> TypeIdentifier<'err, 'builder> {
 impl<'err, 'builder> TypeVisitor for TypeIdentifier<'err, 'builder> {
     fn visit_named_type_expr(&mut self, named_ty: &NamedTypeExpression) {
         if let Some(type_id) =
-            self.builder.get_named_type_id(named_ty.get_name()) {
+            self.builder.named_type_id(named_ty.name()) {
             // Found the already defined type.
             named_ty.set_id(type_id.clone());
         }
         else {
             self.errors.add_error(CheckerError::new(
-                named_ty.get_ident().get_token().clone(),
+                named_ty.ident().token().clone(),
                 vec![],
-                format!("Unknown type {}", named_ty.get_name())
+                format!("Unknown type {}", named_ty.name())
             ));
         }
     }

--- a/src/lex/tests.rs
+++ b/src/lex/tests.rs
@@ -594,7 +594,7 @@ fn log_parses(input: &'static str) {
         next = tokenizer.next();
     }
     for token in tokens {
-        trace!("{} ({:?})", token.get_text(), token.get_type());
+        trace!("{} ({:?})", token.text(), token.get_type());
     }
     trace!("===================\n");
 }

--- a/src/lex/textiter.rs
+++ b/src/lex/textiter.rs
@@ -14,7 +14,7 @@ pub struct TextLocation {
 /// and keeps track of its location.
 pub trait TextIter : Iterator {
     fn peek(&mut self) -> Option<char>;
-    fn get_location(&self) -> TextLocation;
+    fn location(&self) -> TextLocation;
 }
 
 /// A `TextIter` which uses an internal `Peekable<T>`.
@@ -44,7 +44,7 @@ impl<T: Iterator<Item=char>> TextIter for PeekTextIter<T> {
     fn peek(&mut self) -> Option<char> {
         self.iter.peek().cloned()
     }
-    fn get_location(&self) -> TextLocation {
+    fn location(&self) -> TextLocation {
         TextLocation {
             index: self.current_char,
             line: self.current_line,

--- a/src/lex/token.rs
+++ b/src/lex/token.rs
@@ -26,15 +26,15 @@ pub struct Token {
 
 impl Token {
     /// Gets the original source text of this token.
-    pub fn get_text(&self) -> &str {
+    pub fn text(&self) -> &str {
         &self.text
     }
 
-    pub fn get_data(&self) -> &TokenData {
+    pub fn data(&self) -> &TokenData {
         &self.data
     }
 
-    pub fn get_location(&self) -> &TextLocation {
+    pub fn location(&self) -> &TextLocation {
         &self.location
     }
 

--- a/src/lex/tokenizer.rs
+++ b/src/lex/tokenizer.rs
@@ -121,9 +121,9 @@ impl<I: Iterator<Item=char>> IterTokenizer<I> {
         if self.indent_size_stack.len() > 1 {
             self.indent_size_stack.pop();
             trace!("Returning an outdent");
-            return Token::new_outdent(self.iter.get_location())
+            return Token::new_outdent(self.iter.location())
         }
-        return Token::new_eof(self.iter.get_location())
+        return Token::new_eof(self.iter.location())
     }
 
     /// Get the next `BlockBegin` token(s)
@@ -167,7 +167,7 @@ impl<I: Iterator<Item=char>> IterTokenizer<I> {
         else if space_count > current_indent {
             trace!("Indentation greater, pushing {} and returning a BeginBlock", space_count);
             self.indent_size_stack.push(space_count);
-            Token::new_indent(self.iter.get_location())
+            Token::new_indent(self.iter.location())
         }
         else { // space_count < current_indent
             trace!("Indentation is less, going to emit outdents");
@@ -179,7 +179,7 @@ impl<I: Iterator<Item=char>> IterTokenizer<I> {
     /// Emit all needed outdents until tabbing lines up.
     fn next_outdent(&mut self) -> Token {
         trace!("Calling next_outdent");
-        let location = self.iter.get_location();
+        let location = self.iter.location();
         trace!("Current pos: {:?}", location);
         trace!("Indent stack: {:?}", self.indent_size_stack);
         if self.indent_size_stack.len() > 1usize {
@@ -206,7 +206,7 @@ impl<I: Iterator<Item=char>> IterTokenizer<I> {
             trace!("There shouldn't be any indentation but we are indented");
             self.indent_size_stack.push(location.column);
             self.tokenizer_state = TokenizerState::LookingForNewline;
-            return Token::new_indent(self.iter.get_location())
+            return Token::new_indent(self.iter.location())
         }
         trace!("next_outdent done with outdents, calling next_line");
         self.tokenizer_state = TokenizerState::LookingForNewline;
@@ -259,7 +259,7 @@ impl<I: Iterator<Item=char>> IterTokenizer<I> {
             // Give an error for \r at EOF
             if self.iter.peek().is_none() {
                 // TODO error here
-                panic!("Hanging `\\r` at EOF, {:?}", self.iter.get_location());
+                panic!("Hanging `\\r` at EOF, {:?}", self.iter.location());
             }
             // Peek for the \n
             let expected_newline = self.iter.peek().expect("Already peeked");
@@ -294,7 +294,7 @@ impl<I: Iterator<Item=char>> IterTokenizer<I> {
     /// it attempts to match bigger symbols
     fn parse_symbol(&mut self) -> Token {
         use lex::TokenizerSymbolRule::*;
-        let location = self.iter.get_location();
+        let location = self.iter.location();
         let mut sym = String::new();
 
         loop {
@@ -358,7 +358,7 @@ impl<I: Iterator<Item=char>> IterTokenizer<I> {
     /// Parse keyword or identifier
     fn parse_keyword_or_ident(&mut self) -> Token {
         let mut token_string = String::new();
-        let location = self.iter.get_location();
+        let location = self.iter.location();
         let is_kw = self.take_while_ident(&mut token_string);
         if is_kw && self.keywords.get(&Cow::Borrowed(&*token_string)).is_some() {
             Token::new(token_string, location, TokenData::Keyword)
@@ -370,7 +370,7 @@ impl<I: Iterator<Item=char>> IterTokenizer<I> {
     /// Parse a floating point literal
     fn parse_float_literal(&mut self) -> Token {
         let mut token_string = String::new();
-        let location = self.iter.get_location();
+        let location = self.iter.location();
         self.take_while(char::is_number, &mut token_string);
         // First part of number done. Is it a decimal?
         if self.iter.peek().unwrap_or(' ') == '.' {

--- a/src/lex/tokens.rs
+++ b/src/lex/tokens.rs
@@ -64,7 +64,7 @@ macro_rules! declare_tokens {
 
         impl Token {
             pub fn get_type(&self) -> TokenType {
-                match *self.get_data() {
+                match *self.data() {
                     TokenData::NumberLiteral(_)
                     | TokenData::UnitLiteral
                     | TokenData::BoolLiteral(_) => TokenType::Literal,
@@ -73,7 +73,7 @@ macro_rules! declare_tokens {
                     TokenData::EndBlock => TokenType::EndBlock,
                     TokenData::EOF => TokenType::EOF,
                     TokenData::Keyword => {
-                        match self.get_text() {
+                        match self.text() {
                             $(
                                 $kw_val => TokenType::$kw_name,
                             )*
@@ -81,7 +81,7 @@ macro_rules! declare_tokens {
                         }
                     },
                     TokenData::Symbol => {
-                        match self.get_text() {
+                        match self.text() {
                             $(
                                 $sym_val => TokenType::$sym_name,
                             )*
@@ -89,7 +89,7 @@ macro_rules! declare_tokens {
                         }
                     },
                     TokenData::TypeName => {
-                        match self.get_text() {
+                        match self.text() {
                             $(
                                 $ty_val => TokenType::$ty_name,
                             )*

--- a/src/lint/usage_checker.rs
+++ b/src/lint/usage_checker.rs
@@ -13,17 +13,17 @@ impl UsageChecker {
                 "Did not expect immutable {:?} to be mutated", sym);
             if !sym.is_used() {
                 let err_message = format!("{} {} is declared but never used",
-                    sym.get_source().get_name(),
-                    sym.get_declaration().text);
+                    sym.source().name(),
+                    sym.declaration().text);
                 warns.add_warning(
-                    CheckerError::new(sym.get_declaration().clone(), vec![], err_message));
+                    CheckerError::new(sym.declaration().clone(), vec![], err_message));
             }
             if sym.is_mutable() && !sym.is_mutated() {
                 let err_message = format!("{} {} is declared mutable but never mutated",
-                    sym.get_source().get_name(),
-                    sym.get_declaration().text);
+                    sym.source().name(),
+                    sym.declaration().text);
                 warns.add_warning(
-                    CheckerError::new(sym.get_declaration().clone(), vec![], err_message));
+                    CheckerError::new(sym.declaration().clone(), vec![], err_message));
             }
         }
     }
@@ -57,7 +57,7 @@ mod tests {
             vec![],
             "variable x is declared but never used".to_string())
         ];
-        assert_eq!(errors.get_warnings(), &*expected);
+        assert_eq!(errors.warnings(), &*expected);
     }
 
     #[test]
@@ -69,7 +69,7 @@ mod tests {
         sym_checker.check_block(&block);
         let (sym_table, mut errors) = sym_checker.decompose();
         UsageChecker { }.warn_for_unsused(&mut errors, &sym_table);
-        assert_eq!(errors.get_warnings(), &*vec![]);
+        assert_eq!(errors.warnings(), &*vec![]);
     }
 
     #[test]
@@ -81,7 +81,7 @@ mod tests {
         sym_checker.check_block(&block);
         let (sym_table, mut errors) = sym_checker.decompose();
         UsageChecker { }.warn_for_unsused(&mut errors, &sym_table);
-        assert_eq!(errors.get_warnings(), &*vec![]);
+        assert_eq!(errors.warnings(), &*vec![]);
     }
 
     #[test]
@@ -93,7 +93,7 @@ mod tests {
         sym_checker.check_block(&block);
         let (sym_table, mut errors) = sym_checker.decompose();
         UsageChecker { }.warn_for_unsused(&mut errors, &sym_table);
-        assert_eq!(errors.get_warnings(), &*vec![]);
+        assert_eq!(errors.warnings(), &*vec![]);
     }
 
     #[test]
@@ -105,7 +105,7 @@ mod tests {
         sym_checker.check_block(&block);
         let (sym_table, mut errors) = sym_checker.decompose();
         UsageChecker { }.warn_for_unsused(&mut errors, &sym_table);
-        assert_eq!(errors.get_warnings(), &*vec![]);
+        assert_eq!(errors.warnings(), &*vec![]);
     }
 
     #[test]
@@ -126,7 +126,7 @@ mod tests {
             vec![],
             "variable y is declared but never used".to_string())
         ];
-        assert_eq!(errors.get_warnings(), &*expected);
+        assert_eq!(errors.warnings(), &*expected);
     }
 
     #[test]
@@ -147,7 +147,7 @@ mod tests {
             vec![],
             "variable x is declared but never used".to_string())
         ];
-        assert_eq!(errors.get_warnings(), &*expected);
+        assert_eq!(errors.warnings(), &*expected);
     }
 
 }

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -59,7 +59,7 @@ impl<T: Tokenizer> Parser<T> {
     // line
     pub fn peek_is_newline(&mut self, current: &Token) -> bool {
         let (indent, peeked) = self.peek_indented();
-        indent || peeked.get_location().line > current.get_location().line
+        indent || peeked.location().line > current.location().line
     }
 
     /// Consumes the next token from the tokenizer.
@@ -166,7 +166,7 @@ impl<T: Tokenizer> Parser<T> {
             -> Result<Token, ParseError> {
         trace!("Consuming name {}", expected_name);
         let token = try!(self.consume_type(expected_type));
-        if token.get_text() != expected_name {
+        if token.text() != expected_name {
             Err(ParseError::ExpectedToken {
                 expected: expected_type,
                 got: token.into()
@@ -249,7 +249,7 @@ impl<T: Tokenizer> Parser<T> {
         }
         if let Some(found_parser) = self.expr_prefix_parsers.get(&token_type) {
             trace!("Found a parser to parse ({:?}, {:?})",
-                token.get_type(), token.get_text());
+                token.get_type(), token.text());
             prefix = found_parser.clone();
         }
         else {
@@ -459,7 +459,7 @@ impl<T: Tokenizer> Parser<T> {
         use std::ops::Deref;
             let looked_ahead = self.look_ahead(1).get_type();
         if let Some(infix_parser) = self.expr_infix_parsers.get(&looked_ahead).cloned() {
-            infix_parser.get_precedence()
+            infix_parser.precedence()
         } else {
             Precedence::Min
         }

--- a/src/parse/symbol/expression/assign_op.rs
+++ b/src/parse/symbol/expression/assign_op.rs
@@ -32,7 +32,7 @@ impl<T: Tokenizer> InfixParser<Expression, T> for AssignOpParser {
             Box::new(right_value)));
         Ok(Expression::Assignment(Assignment::new(lvalue, Box::new(right_expr))))
     }
-    fn get_precedence(&self) -> Precedence {
+    fn precedence(&self) -> Precedence {
         Precedence::Assign
     }
 }

--- a/src/parse/symbol/expression/assignment.rs
+++ b/src/parse/symbol/expression/assignment.rs
@@ -24,7 +24,7 @@ impl<T: Tokenizer> InfixParser<Expression, T> for AssignmentParser {
         let right = try!(right_expr.expect_value());
         Ok(Expression::Assignment(Assignment::new(ident, Box::new(right))))
     }
-    fn get_precedence(&self) -> Precedence {
+    fn precedence(&self) -> Precedence {
         Precedence::Assign
     }
 }

--- a/src/parse/symbol/expression/fn_call.rs
+++ b/src/parse/symbol/expression/fn_call.rs
@@ -36,7 +36,7 @@ impl<T: Tokenizer> InfixParser<Expression, T> for FnCallParser {
                 let arg = try!(parser.expression(Precedence::Min));
                 if let Expression::VariableRef(ident) = arg {
                     if parser.next_type() == TokenType::Colon {
-                        trace!("Argument {} is a named arg", ident.get_name());
+                        trace!("Argument {} is a named arg", ident.name());
                         parser.consume();
                         let arg_value = try!(parser.expression(Precedence::Min));
                         call_args.push(CallArgument::named(ident, arg_value));
@@ -67,7 +67,7 @@ impl<T: Tokenizer> InfixParser<Expression, T> for FnCallParser {
         Ok(Expression::FnCall(call))
     }
 
-    fn get_precedence(&self) -> Precedence {
+    fn precedence(&self) -> Precedence {
         Precedence::Paren
     }
 }

--- a/src/parse/symbol/expression/if_expr.rs
+++ b/src/parse/symbol/expression/if_expr.rs
@@ -21,7 +21,7 @@ pub struct IfExpressionParser { }
 impl<T: Tokenizer> PrefixParser<Expression, T> for IfExpressionParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token)
             -> ParseResult<Expression> {
-        debug_assert!(token.get_text() == "if",
+        debug_assert!(token.text() == "if",
             "Invlaid token {:?} in IfExpressionParser", token);
         trace!("Parsing conditional of if expression");
         let condition = try!(parser.expression(Precedence::Min));

--- a/src/parse/symbol/expression/literal.rs
+++ b/src/parse/symbol/expression/literal.rs
@@ -15,7 +15,7 @@ use ast::*;
 pub struct LiteralParser { }
 impl<T: Tokenizer> PrefixParser<Expression, T> for LiteralParser {
     fn parse(&self, _parser: &mut Parser<T>, token: Token) -> ParseResult<Expression> {
-        match *token.get_data() {
+        match *token.data() {
             TokenData::NumberLiteral(val) =>
                 Ok(Expression::Literal(Literal::new(token, LiteralValue::Float(val)))),
             _ => Err(ParseError::ExpectedToken {

--- a/src/parse/symbol/expression/mod.rs
+++ b/src/parse/symbol/expression/mod.rs
@@ -39,7 +39,7 @@ impl<T: Tokenizer> InfixParser<Expression, T> for BinOpExprSymbol {
         Ok(Expression::BinaryOp(
             BinaryOperation::new(bin_operator, token, Box::new(left), Box::new(right))))
     }
-    fn get_precedence(&self) -> Precedence {
+    fn precedence(&self) -> Precedence {
         self.precedence
     }
 }

--- a/src/parse/symbol/item/function.rs
+++ b/src/parse/symbol/item/function.rs
@@ -67,7 +67,7 @@ impl<T: Tokenizer> PrefixParser<Item, T> for FnDeclarationParser {
         else {
             (TypeExpression::Named(NamedTypeExpression::new(Identifier::new(
                 Token::new_ident("()",
-                        name.get_token().get_location().clone())))), false)
+                        name.token().location().clone())))), false)
         };
 
         // This is gonna require a comment in the place of Python's `pass`.

--- a/src/parse/symbol/mod.rs
+++ b/src/parse/symbol/mod.rs
@@ -31,7 +31,7 @@ pub trait PrefixParser<E, T: Tokenizer> {
 /// Generic parser trait used to parse AST nodes of type E in the infix position.
 pub trait InfixParser<E, T: Tokenizer> {
     fn parse(&self, parser: &mut Parser<T>, left: E, token: Token) -> ParseResult<E>;
-    fn get_precedence(&self) -> Precedence;
+    fn precedence(&self) -> Precedence;
 }
 
 // TODO This can't be implemented until we have a way of knowing when to stop calling
@@ -63,7 +63,7 @@ impl<'p, E, T: Tokenizer> PrefixParser for CommaSeparatedParser<'p, E, T> {
         let mut found = Vec::new();
         loop {
             let next_token = parser.consume();
-            if next_token.get_type() == TokenType::Comma {
+            if next_token.type() == TokenType::Comma {
                 trace!("Comma parser: found leading comma");
                 return Err(ParseError::LazyString("Unexpected comma in comma separated list"))
             }

--- a/src/parse/symbol/statement/do_block.rs
+++ b/src/parse/symbol/statement/do_block.rs
@@ -20,7 +20,7 @@ use parse::symbol::PrefixParser;
 pub struct DoBlockParser { }
 impl<T: Tokenizer> PrefixParser<Statement, T> for DoBlockParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Statement> {
-        debug_assert!(token.get_text() == "do",
+        debug_assert!(token.text() == "do",
             "Invalid token {:?} in DoBlockParser", token);
         if parser.next_type() == TokenType::BeginBlock {
             parser.consume();

--- a/src/parse/symbol/statement/return_stmt.rs
+++ b/src/parse/symbol/statement/return_stmt.rs
@@ -16,7 +16,7 @@ use parse::symbol::{PrefixParser, Precedence};
 pub struct ReturnParser { }
 impl<T: Tokenizer> PrefixParser<Statement, T> for ReturnParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Statement> {
-        debug_assert!(token.get_text() == tokens::Return,
+        debug_assert!(token.text() == tokens::Return,
                       "Return parser called with non-return {:?}", token);
         // If the next statement is on a newline then empty return.
         // Also empty return if next token is deindent

--- a/src/parse/symbol/types/array.rs
+++ b/src/parse/symbol/types/array.rs
@@ -11,7 +11,7 @@ pub struct ArrayTypeParser;
 
 impl<T: Tokenizer> PrefixParser<T, TypeExpression> for ArrayTypeParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<TypeExpression> {
-        debug_assert!(token.get_type() == TokenType::LeftBracket,
+        debug_assert!(token.type() == TokenType::LeftBracket,
             "Array type parser called with token {:?}", token);
         let main_type = try!(parser.type_expr());
         match parser.next_type() {

--- a/src/parse/symbol/types/mod.rs
+++ b/src/parse/symbol/types/mod.rs
@@ -21,7 +21,7 @@ impl<T: Tokenizer> PrefixParser<TypeExpression, T> for NamedTypeParser {
              -> ParseResult<TypeExpression> {
         debug_assert!(token.get_type() == TokenType::Ident,
             "NamedTypeParser called with non-name token {:?}", token);
-        trace!("Parsing named type {}", token.get_text());
+        trace!("Parsing named type {}", token.text());
         Ok(TypeExpression::Named(NamedTypeExpression::new(
             Identifier::new(token)
         )))

--- a/src/parse/symbol/types/named.rs
+++ b/src/parse/symbol/types/named.rs
@@ -18,9 +18,9 @@ pub struct NamedTypeParser;
 
 impl<T: Tokenizer> PrefixParser<TypeExpression, T> for NamedTypeParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<TypeExpression> {
-        debug_assert!(token.get_type() == TokenType::Identifier,
+        debug_assert!(token.type() == TokenType::Identifier,
             "NamedTypeParser called with non-name token {:?}", token);
-        trace!("Parsing named type {}", token.get_text());
+        trace!("Parsing named type {}", token.text());
         let ident = Identifier::new(token);
         if parser.next_type() == TokenType::LeftAngle {
             // TODO this should be split into its own parser.
@@ -33,7 +33,7 @@ impl<T: Tokenizer> PrefixParser<TypeExpression, T> for NamedTypeParser {
             let mut expect_comma = false;
             loop {
                 let next = parser.consume();
-                match next.get_type() {
+                match next.type() {
                     TokenType::RightAngle => {
                         if params.is_empty() {
                             return Err(ParseError::LazyString("No params specified".into()))

--- a/src/parse/tests.rs
+++ b/src/parse/tests.rs
@@ -25,9 +25,9 @@ pub fn eof_parser() -> Parser<IterTokenizer<Chars<'static>>> {
 
 /// Check that two tokens are equal, without looking at locatoin
 pub fn token_eq(expected: Token, got: Token) {
-    assert_eq!(expected.get_data(), got.get_data(),
+    assert_eq!(expected.data(), got.data(),
         "token_eq: {:?} != {:?}", expected, got);
-    assert_eq!(expected.get_text(), got.get_text(),
+    assert_eq!(expected.text(), got.text(),
         "token_eq: {:?} != {:?}", expected, got);
 }
 
@@ -37,56 +37,56 @@ pub fn token_eq(expected: Token, got: Token) {
 pub fn expression_match(expected: &Expression, got: &Expression) {
     match (expected, got) {
         (&Expression::Literal(ref lit), &Expression::Literal(ref lit2)) => {
-            assert_eq!(lit.get_value(), lit2.get_value(),
+            assert_eq!(lit.value(), lit2.value(),
                 "Expression mismatch in literals: expected {:?}, got {:?}",
-                lit.get_value(), lit2.get_value());
+                lit.value(), lit2.value());
         },
         (&Expression::VariableRef(ref var), &Expression::VariableRef(ref var2)) => {
-            assert_eq!(var.get_name(), var2.get_name(),
+            assert_eq!(var.name(), var2.name(),
                 "Variable reference mismatch: expected {:?}, got {:?}",
-                var.get_name(), var2.get_name());
+                var.name(), var2.name());
         },
         (&Expression::BinaryOp(ref bin), &Expression::BinaryOp(ref bin2)) => {
-            assert_eq!(bin.get_operator(), bin2.get_operator(),
+            assert_eq!(bin.operator(), bin2.operator(),
                 "Binary expression mismatch:\nExpected {:#?}\nGot: {:#?}",
                 bin, bin2);
-            println!("Checking {:?} lhs equality", bin.get_operator());
-            expression_match(bin.get_left(), bin2.get_left());
-            println!("Checking {:?} rhs equality", bin.get_operator());
-            expression_match(bin.get_right(), bin2.get_right());
+            println!("Checking {:?} lhs equality", bin.operator());
+            expression_match(bin.left(), bin2.left());
+            println!("Checking {:?} rhs equality", bin.operator());
+            expression_match(bin.right(), bin2.right());
         },
         (&Expression::UnaryOp(ref un), &Expression::UnaryOp(ref un2)) => {
-            assert_eq!(un.get_operator(), un2.get_operator(),
+            assert_eq!(un.operator(), un2.operator(),
                 "Unary expression mismatch:\nExpected {:#?}\nGot: {:#?}",
                 un, un2);
-            println!("Checking {:?} equality", un.get_operator());
-            expression_match(un.get_inner(), un2.get_inner());
+            println!("Checking {:?} equality", un.operator());
+            expression_match(un.inner(), un2.inner());
         },
         (&Expression::IfExpression(ref left), &Expression::IfExpression(ref right)) => {
             println!("Checking ifexpr equality");
-            expression_match(left.get_condition(), right.get_condition());
-            expression_match(left.get_true_expr(), right.get_true_expr());
-            expression_match(left.get_true_expr(), right.get_true_expr());
+            expression_match(left.condition(), right.condition());
+            expression_match(left.true_expr(), right.true_expr());
+            expression_match(left.true_expr(), right.true_expr());
         },
         (&Expression::FnCall(ref left), &Expression::FnCall(ref right)) => {
-            assert_eq!(left.get_text(), right.get_text(),
+            assert_eq!(left.text(), right.text(),
                 "Fn call mismatch:\nExpected: {:#?}\nGot: {:#?}",
                 left, right);
             // TODO match on args
         }
         (&Expression::Assignment(ref assign), &Expression::Assignment(ref assign2)) => {
-            assert_eq!(assign.get_lvalue(), assign2.get_lvalue(),
+            assert_eq!(assign.lvalue(), assign2.lvalue(),
                 "Assignment mismatch:\nExpected: {:#?}\nGot: {:#?}",
-                assign.get_lvalue(), assign2.get_lvalue());
-            println!("Checking assignment to {}", assign.get_lvalue().get_name());
-            expression_match(assign.get_rvalue(), assign2.get_rvalue());
+                assign.lvalue(), assign2.lvalue());
+            println!("Checking assignment to {}", assign.lvalue().name());
+            expression_match(assign.rvalue(), assign2.rvalue());
         },
         (&Expression::Declaration(ref dec), &Expression::Declaration(ref dec2)) => {
-            assert!(dec.get_name() == dec2.get_name() && dec.is_mut() == dec2.is_mut(),
+            assert!(dec.name() == dec2.name() && dec.is_mut() == dec2.is_mut(),
                 "Declaration mismatch:\nExpected: {:#?}\nGot: {:#?}",
                 dec, dec2);
-            println!("Checking declaration of {}", dec.get_name());
-            expression_match(dec.get_value(), dec2.get_value());
+            println!("Checking declaration of {}", dec.name());
+            expression_match(dec.value(), dec2.value());
         },
         (ref other, ref other2) => {
             panic!("Expressions did not match:\nExpected {:#?}\nGot {:#?}",
@@ -102,7 +102,7 @@ pub fn statement_match(expected: &Statement, got: &Statement) {
         },
         (&Statement::Return(ref left), &Statement::Return(ref right)) => {
             println!("Checking return stmts");
-            match (left.get_value(), right.get_value()) {
+            match (left.value(), right.value()) {
                 (Some(ref left_val), Some(ref right_val)) => {
                     expression_match(left_val, right_val);
                 },
@@ -115,22 +115,22 @@ pub fn statement_match(expected: &Statement, got: &Statement) {
         },
         (&Statement::DoBlock(ref left), &Statement::DoBlock(ref right)) => {
             println!("Checking do block match");
-            block_match(left.get_block(), right.get_block());
+            block_match(left.block(), right.block());
         },
         (&Statement::IfBlock(ref left), &Statement::IfBlock(ref right)) => {
             println!("Checking if blocks");
-            let left_conditionals = left.get_conditionals();
-            let right_conditionals = right.get_conditionals();
+            let left_conditionals = left.conditionals();
+            let right_conditionals = right.conditionals();
             assert_eq!(left_conditionals.len(), right_conditionals.len(),
                 "If block conditional length mismatch:\nExpected {:#?}\nGot: {:#?}",
                 left, right);
             for (left_cond, right_cond) in
                         left_conditionals.iter().zip(right_conditionals.iter()) {
                 println!("Checking if block conditional");
-                expression_match(left_cond.get_condition(), right_cond.get_condition());
-                block_match(left_cond.get_block(), right_cond.get_block());
+                expression_match(left_cond.condition(), right_cond.condition());
+                block_match(left_cond.block(), right_cond.block());
             }
-            match (left.get_else(), right.get_else()) {
+            match (left.else_block(), right.else_block()) {
                 (Some(&(_, ref left)), Some(&(_, ref right))) => {
                     println!("Checking else blocks");
                     block_match(left, right);
@@ -149,11 +149,11 @@ pub fn statement_match(expected: &Statement, got: &Statement) {
     }
 
     fn block_match(expected: &Block, got: &Block) {
-        assert_eq!(expected.get_stmts().len(), got.get_stmts().len(),
+        assert_eq!(expected.stmts().len(), got.stmts().len(),
             "Blocks had differing stmt counts:\nExpected: {:#?}\nGot: {:#?}",
             expected, got);
         for (ref left, ref right) in
-                    expected.get_stmts().iter().zip(got.get_stmts().iter()) {
+                    expected.stmts().iter().zip(got.stmts().iter()) {
             statement_match(left, right);
         }
     }

--- a/tests/tokenizer.rs
+++ b/tests/tokenizer.rs
@@ -53,8 +53,8 @@ fn verify_keywords_list(fixture_name: &'static str) {
             assert_eq!(expected_type, token.get_type(),
                 "\nExpected {:?} from line {}, got {:?}", expected_type, current_line, token);
             println!("{}: Matched type {:?}", current_line, expected_type);
-            assert_eq!(token_text, token.get_text(),
-                "\nExpected {} from line {}, got {}", token_text, current_line, token.get_text());
+            assert_eq!(token_text, token.text(),
+                "\nExpected {} from line {}, got {}", token_text, current_line, token.text());
             println!("{}: Matched text {}", current_line, token_text);
         }
         else if token.get_type() != TokenType::EOF {


### PR DESCRIPTION
This does not include the LLVM module, where we honor LLVM's naming style more.

Closes #54.