### PR TITLE
Split `Operator` enum into `UnaryOperator` and `BinaryOperator`

### DIFF
--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -3,9 +3,7 @@
 //! Expression values are used in the `Expression` and `Statement` contexts.
 //! They are usually emitted as asm instructions operating on variables.
 
-use ast::{Statement, Identifier, Operator, Block, ScopedId};
-use ast::types::TypeExpression;
-
+use ast::*;
 use lex::{Token, TokenType, TokenData};
 use parse::{ParseResult, ParseError, ExpectedNextType};
 
@@ -148,13 +146,13 @@ impl Literal {
 /// Maths style binary operations (may be split up later)
 #[derive(Debug, PartialEq, Clone)]
 pub struct BinaryOperation {
-    operator: Operator,
+    operator: BinaryOperator,
     op_token: Token,
     left: Box<Expression>,
     right: Box<Expression>
 }
 impl BinaryOperation {
-    pub fn new(operator: Operator, op_token: Token,
+    pub fn new(operator: BinaryOperator, op_token: Token,
         left: Box<Expression>, right: Box<Expression>) -> BinaryOperation {
         BinaryOperation {
             operator: operator,
@@ -163,7 +161,7 @@ impl BinaryOperation {
             right: right
         }
     }
-    pub fn operator(&self) -> Operator {
+    pub fn operator(&self) -> BinaryOperator {
         self.operator
     }
     pub fn left(&self) -> &Expression {
@@ -177,13 +175,13 @@ impl BinaryOperation {
 /// Unary operation
 #[derive(Debug, PartialEq, Clone)]
 pub struct UnaryOperation {
-    operator: Operator,
+    operator: UnaryOperator,
     op_token: Token,
     expression: Box<Expression>
 }
 impl UnaryOperation {
     /// Creates a new unary operation
-    pub fn new(operator: Operator,
+    pub fn new(operator: UnaryOperator,
                op_token: Token,
                expression: Box<Expression>) -> UnaryOperation {
         UnaryOperation {
@@ -192,7 +190,7 @@ impl UnaryOperation {
             expression: expression
         }
     }
-    pub fn operator(&self) -> Operator {
+    pub fn operator(&self) -> UnaryOperator {
         self.operator
     }
     pub fn inner(&self) -> &Expression {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -22,7 +22,7 @@ pub use self::index::*;
 pub use self::expression::*;
 pub use self::item::*;
 pub use self::stmt::*;
-pub use self::operator::Operator;
+pub use self::operator::*;
 pub use self::types::*;
 
 use std::cell::{Cell, RefCell, Ref};

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -33,4 +33,6 @@ pub enum BinaryOperator {
 pub enum UnaryOperator {
     /// Negation
     Negation,
+    /// No-op
+    Addition,
 }

--- a/src/ast/operator.rs
+++ b/src/ast/operator.rs
@@ -1,31 +1,36 @@
 //! Operators are used to indicate whether the parser has encountered
 //! a standard operator or a custom one.
 
-/// Standard set of operators + custom
+/// Binary operators
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Operator {
-    /// Addition
+pub enum BinaryOperator {
+    /// Numeric addition
     Addition,
-    /// Subtraction **and** negation
+    /// Numeric subtraction
     Subtraction,
-    /// Multiplication
+    /// Numeric multiplication
     Multiplication,
-    /// Division
+    /// Numeric division
     Division,
-    /// Modulus
+    /// Numeric modulus
     Modulus,
     /// Equality test
     Equality,
     /// Non-equality test
     NonEquality,
-    // Less than test
+    // Numeric less than test
     LessThan,
-    /// Greater than test
+    /// Numeric reater than test
     GreaterThan,
-    /// Less than equals test
+    /// Numeric less than equals test
     LessThanEquals,
-    /// Greater than equals test
+    /// Numeric greater than equals test
     GreaterThanEquals,
-    /// Custom operator
-    Custom
+}
+
+/// Unary operators
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UnaryOperator {
+    /// Negation
+    Negation,
 }

--- a/src/identify/types/expr_typographer.rs
+++ b/src/identify/types/expr_typographer.rs
@@ -324,7 +324,7 @@ impl<'err, 'builder, 'graph> ExpressionVisitor
         let float_type = self.primitive_type_ix("float");
         // Require a numeric value for `-expr`
         match unary_op.operator() {
-            Operator::Subtraction | Operator::Addition => {
+            UnaryOperator::Negation | UnaryOperator::Addition => {
                 self.visit_expression(unary_op.inner());
                 // t_expr = tint
                 self.graph.add_inference(self.current_type, float_type,
@@ -333,16 +333,11 @@ impl<'err, 'builder, 'graph> ExpressionVisitor
                 self.graph.add_inference(unary_op_expr_ty, float_type,
                     InferenceSource::NumericOperator);
             },
-            // This match should be exhaustive.
-            // https://github.com/immington-industries/protosnirk/issues/29
-            _ => {
-                unreachable!("Unexpected unary operation {:?}", unary_op);
-            }
         }
     }
 
     fn visit_binary_op(&mut self, bin_op: &BinaryOperation) {
-        use ast::Operator::*;
+        use ast::BinaryOperator::*;
         // Depending on the binary operation, we can infer types of each side.
         // Get the left and right TypeIds.
         self.visit_expression(bin_op.left());
@@ -392,9 +387,6 @@ impl<'err, 'builder, 'graph> ExpressionVisitor
                 self.graph.add_inference(binop_type, float_type,
                     InferenceSource::NumericOperator);
             },
-            Custom => {
-                unreachable!("Unexpected binary operation {:?}", bin_op)
-            }
         }
         self.current_type = binop_type;
     }

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -28,8 +28,6 @@ pub struct Parser<T: Tokenizer> {
     expr_prefix_parsers: HashMap<TokenType, Rc<PrefixParser<Expression, T> + 'static>>,
     /// Parses for parsing program items (struct/enum/fn declarations, etc.)
     item_parsers: HashMap<TokenType, Rc<PrefixParser<Item, T> + 'static>>,
-    /// Mapping of tokens to applied operators
-    token_operators: HashMap<TokenType, Operator>,
     /// Allows the parser to skip over unneeded indentation
     indent_rules: Vec<IndentationRule>,
 }
@@ -344,17 +342,37 @@ impl<T: Tokenizer> Parser<T> {
         }
     }
 
-    /// Gets the operator registered for the given token.
-    pub fn operator(&self, token_type: TokenType) -> Result<Operator, ParseError> {
-        use std::ops::Deref;
-        use std::borrow::Cow;
-        if let Some(op) = self.token_operators.get(&token_type) {
-            Ok(*op)
-        } else {
-            Err(ParseError::UnknownOperator {
-                text: Cow::from(format!("{:?}", token_type)),
-                token_type
-            })
+    /// Gets the binary operator used for the given token.
+    pub fn binary_operator(&self,
+                           token_type: TokenType)
+                           -> Result<BinaryOperator, ParseError> {
+        use lex::TokenType::*;
+        match token_type {
+            Plus => Ok(BinaryOperator::Addition),
+            Minus => Ok(BinaryOperator::Subtraction),
+            Star => Ok(BinaryOperator::Multiplication),
+            Slash => Ok(BinaryOperator::Division),
+            DoubleEquals => Ok(BinaryOperator::Equality),
+            NotEquals => Ok(BinaryOperator::NonEquality),
+            LessThanEquals => Ok(BinaryOperator::LessThanEquals),
+            GreaterThanEquals => Ok(BinaryOperator::GreaterThanEquals),
+            _ => Err(ParseError::UnknownOperator {
+                    text: Cow::from(format!("{:?}", token_type)),
+                    token_type
+                })
+        }
+    }
+
+    pub fn unary_operator(&self,
+                          token_type: TokenType)
+                          -> Result<UnaryOperator, ParseError> {
+        use lex::TokenType::*;
+        match token_type {
+            Minus => Ok(UnaryOperator::Negation),
+            _ => Err(ParseError::UnknownOperator {
+                    text: Cow::from(format!("{:?}", token_type)),
+                    token_type
+                })
         }
     }
 
@@ -410,24 +428,6 @@ impl<T: Tokenizer> Parser<T> {
         hashmap![
             Fn => Rc::new(FnDeclarationParser { }) as Rc<PrefixParser<Item, T>>,
         ];
-        let operator_map: HashMap<TokenType, Operator> = hashmap![
-            Plus => Operator::Addition,
-            PlusEquals => Operator::Addition,
-            Minus => Operator::Subtraction,
-            MinusEquals => Operator::Subtraction,
-            Star => Operator::Multiplication,
-            StarEquals => Operator::Multiplication,
-            Slash => Operator::Division,
-            SlashEquals => Operator::Division,
-            Percent => Operator::Modulus,
-            PercentEquals => Operator::Modulus,
-            LeftAngle => Operator::LessThan,
-            LessThanEquals => Operator::LessThanEquals,
-            RightAngle => Operator::GreaterThan,
-            GreaterThanEquals => Operator::GreaterThan,
-            DoubleEquals => Operator::Equality,
-            NotEquals => Operator::NonEquality
-        ];
 
         Parser {
             tokenizer: tokenizer,
@@ -436,7 +436,6 @@ impl<T: Tokenizer> Parser<T> {
             stmt_prefix_parsers: stmt_prefix_map,
             expr_prefix_parsers: expr_prefix_map,
             expr_infix_parsers: expr_infix_map,
-            token_operators: operator_map,
             indent_rules: Vec::new(),
         }
     }

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -352,8 +352,11 @@ impl<T: Tokenizer> Parser<T> {
             Minus => Ok(BinaryOperator::Subtraction),
             Star => Ok(BinaryOperator::Multiplication),
             Slash => Ok(BinaryOperator::Division),
+            Percent => Ok(BinaryOperator::Modulus),
             DoubleEquals => Ok(BinaryOperator::Equality),
             NotEquals => Ok(BinaryOperator::NonEquality),
+            LeftAngle => Ok(BinaryOperator::LessThan),
+            RightAngle => Ok(BinaryOperator::GreaterThan),
             LessThanEquals => Ok(BinaryOperator::LessThanEquals),
             GreaterThanEquals => Ok(BinaryOperator::GreaterThanEquals),
             _ => Err(ParseError::UnknownOperator {

--- a/src/parse/symbol/expression/assign_op.rs
+++ b/src/parse/symbol/expression/assign_op.rs
@@ -23,7 +23,7 @@ impl<T: Tokenizer> InfixParser<Expression, T> for AssignOpParser {
         let lvalue = try!(left.expect_identifier());
         let right_expr = try!(parser.expression(Precedence::Min));
         let right_value = try!(right_expr.expect_value());
-        let operator = try!(parser.operator(token.get_type()));
+        let operator = try!(parser.binary_operator(token.get_type()));
         // We parse it here into an expanded expression.
         let right_expr = Expression::BinaryOp(BinaryOperation::new(
             operator,

--- a/src/parse/symbol/expression/mod.rs
+++ b/src/parse/symbol/expression/mod.rs
@@ -35,7 +35,7 @@ impl<T: Tokenizer> InfixParser<Expression, T> for BinOpExprSymbol {
     fn parse(&self, parser: &mut Parser<T>,
              left: Expression, token: Token) -> ParseResult<Expression> {
         let right: Expression = try!(parser.expression(self.precedence));
-        let bin_operator = try!(parser.operator(token.get_type()));
+        let bin_operator = try!(parser.binary_operator(token.get_type()));
         Ok(Expression::BinaryOp(
             BinaryOperation::new(bin_operator, token, Box::new(left), Box::new(right))))
     }
@@ -62,7 +62,7 @@ impl<T: Tokenizer> PrefixParser<Expression, T> for UnaryOpExprSymbol {
              parser: &mut Parser<T>, token: Token) -> ParseResult<Expression> {
         let right_expr = try!(parser.expression(self.precedence));
         let right_value = try!(right_expr.expect_value());
-        let operator = try!(parser.operator(token.get_type()));
+        let operator = try!(parser.unary_operator(token.get_type()));
         Ok(Expression::UnaryOp(UnaryOperation::new(operator, token, Box::new(right_value))))
     }
 }
@@ -71,9 +71,4 @@ impl UnaryOpExprSymbol {
     pub fn with_precedence<T: Tokenizer>(precedence: Precedence) -> Rc<PrefixParser<Expression, T>> {
         Rc::new(UnaryOpExprSymbol { precedence: precedence }) as Rc<PrefixParser<Expression, T>>
     }
-}
-
-#[cfg(test)]
-mod tests {
-
 }

--- a/src/parse/symbol/expression/parens.rs
+++ b/src/parse/symbol/expression/parens.rs
@@ -27,8 +27,3 @@ impl<T: Tokenizer> PrefixParser<Expression, T> for ParensParser {
         Ok(inner)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    // TODO test basic parens, unmatching, indentation
-}

--- a/src/parse/symbol/precedence.rs
+++ b/src/parse/symbol/precedence.rs
@@ -2,7 +2,6 @@
 
 use std::mem;
 
-#[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Precedence {
     /// Extra value on the end
@@ -29,16 +28,4 @@ pub enum Precedence {
     Paren,
     /// Extra value on the end
     Max
-}
-
-#[cfg(test)]
-mod test {
-    use std::mem;
-    use super::*;
-
-    #[test]
-    fn it_has_derived_ord() {
-        assert!(Precedence::Max > Precedence::Min);
-        assert!(Precedence::MulDiv > Precedence::AddSub);
-    }
 }


### PR DESCRIPTION
Closes #29.