### PR TITLE
Remove beta build from matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,6 @@ git:
 language: rust
 rust:
   - stable
-  - beta
-
-matrix:
-  allow_failures:
-    - rust:
-        - beta
-  fast_finish: true
 
 cache:
   - cargo
@@ -52,4 +45,4 @@ script:
   - find /usr/bin -name "*llvm*" | sort
   - llvm-config --version
   - cargo check --verbose
-  - cargo test --verbose
+  - cargo test --all --verbose


### PR DESCRIPTION
Travis is intermittently failing on the `apt-get` and "install Rustup" portions of builds, which I end up restarting, which breaks the "fail-fast" part of the matrix. I'm not particularly interested in using non-stable features, and I don't think protosnirk code will end up highlighting regressions in Rust beta, so I'm disabling the Rust beta build again.