### PR TITLE
User defined types (type aliases)

### DIFF
--- a/src/ast/item.rs
+++ b/src/ast/item.rs
@@ -28,7 +28,9 @@ impl Unit {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Item {
     /// Declaraion of a function
-    BlockFnDeclaration(BlockFnDeclaration)
+    BlockFnDeclaration(BlockFnDeclaration),
+    /// Declaration of a type alias
+    TypeAliasDeclaration(TypeAliasDeclaration)
 }
 
 /// Declaration of a function
@@ -41,6 +43,7 @@ pub struct BlockFnDeclaration {
     explicit_ret_ty: bool,
     block: Block,
 }
+
 impl BlockFnDeclaration {
     /// Create a new FnDeclaration
     pub fn new(fn_token: Token,
@@ -64,7 +67,7 @@ impl BlockFnDeclaration {
     }
     pub fn params(&self) -> &[(Identifier, TypeExpression)] {
         &self.params
-    } 
+    }
     pub fn return_type(&self) -> &TypeExpression {
         &self.ret_ty
     }
@@ -84,5 +87,46 @@ impl BlockFnDeclaration {
     /// Get the block inside the function
     pub fn block(&self) -> &Block {
         &self.block
+    }
+}
+
+/// Declaration of a type alias
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypeAliasDeclaration {
+    typedef_token: Token,
+    alias_ident: Identifier,
+    type_expr: TypeExpression
+}
+
+impl TypeAliasDeclaration {
+    pub fn new(typedef_token: Token,
+               alias_ident: Identifier,
+               type_expr: TypeExpression)
+               -> TypeAliasDeclaration {
+        TypeAliasDeclaration { typedef_token, alias_ident, type_expr }
+    }
+
+    pub fn token(&self) -> &Token {
+        &self.typedef_token
+    }
+
+    pub fn ident(&self) -> &Identifier {
+        &self.alias_ident
+    }
+
+    pub fn id<'a>(&'a self) -> Ref<'a, ScopedId> {
+        self.alias_ident.id()
+    }
+
+    pub fn set_id(&self, id: ScopedId) {
+        self.alias_ident.set_id(id)
+    }
+
+    pub fn name(&self) -> &str {
+        self.alias_ident.name()
+    }
+
+    pub fn type_expr(&self) -> &TypeExpression {
+        &self.type_expr
     }
 }

--- a/src/ast/item.rs
+++ b/src/ast/item.rs
@@ -30,7 +30,7 @@ pub enum Item {
     /// Declaraion of a function
     BlockFnDeclaration(BlockFnDeclaration),
     /// Declaration of a type alias
-    TypeAliasDeclaration(TypeAliasDeclaration)
+    Typedef(Typedef)
 }
 
 /// Declaration of a function
@@ -92,18 +92,18 @@ impl BlockFnDeclaration {
 
 /// Declaration of a type alias
 #[derive(Debug, Clone, PartialEq)]
-pub struct TypeAliasDeclaration {
+pub struct Typedef {
     typedef_token: Token,
     alias_ident: Identifier,
     type_expr: TypeExpression
 }
 
-impl TypeAliasDeclaration {
+impl Typedef {
     pub fn new(typedef_token: Token,
                alias_ident: Identifier,
                type_expr: TypeExpression)
-               -> TypeAliasDeclaration {
-        TypeAliasDeclaration { typedef_token, alias_ident, type_expr }
+               -> Typedef {
+        Typedef { typedef_token, alias_ident, type_expr }
     }
 
     pub fn token(&self) -> &Token {

--- a/src/ast/visit/visitor.rs
+++ b/src/ast/visit/visitor.rs
@@ -20,14 +20,14 @@ pub trait ItemVisitor {
             Item::BlockFnDeclaration(ref block_fn_decl) => {
                 self.visit_block_fn_decl(block_fn_decl);
             },
-            Item::TypeAliasDeclaration(ref type_alias_decl) => {
-                self.visit_type_alias_decl(type_alias_decl);
+            Item::Typedef(ref typedef) => {
+                self.visit_typedef(typedef);
             }
         }
     }
 
     fn visit_block_fn_decl(&mut self, block_fn_decl: &BlockFnDeclaration);
-    fn visit_type_alias_decl(&mut self, type_alias_decl: &TypeAliasDeclaration);
+    fn visit_typedef(&mut self, typedef: &Typedef);
 }
 
 /// A visitor which can visit type expressions in code.

--- a/src/ast/visit/visitor.rs
+++ b/src/ast/visit/visitor.rs
@@ -19,11 +19,15 @@ pub trait ItemVisitor {
         match *item {
             Item::BlockFnDeclaration(ref block_fn_decl) => {
                 self.visit_block_fn_decl(block_fn_decl);
+            },
+            Item::TypeAliasDeclaration(ref type_alias_decl) => {
+                self.visit_type_alias_decl(type_alias_decl);
             }
         }
     }
 
     fn visit_block_fn_decl(&mut self, block_fn_decl: &BlockFnDeclaration);
+    fn visit_type_alias_decl(&mut self, type_alias_decl: &TypeAliasDeclaration);
 }
 
 /// A visitor which can visit type expressions in code.

--- a/src/check/types/type_concretifier.rs
+++ b/src/check/types/type_concretifier.rs
@@ -120,7 +120,7 @@ impl<'err, 'builder, 'graph> ItemVisitor
         self.visit_block(block_fn.block());
     }
 
-    fn visit_type_alias_decl(&mut self, typedef: &TypeAliasDeclaration) {
+    fn visit_typedef(&mut self, typedef: &Typedef) {
         trace!("Visiting typedef {}", typedef.name());
         self.infer_var(&typedef.id(), typedef.token(),
             format!("typedef {}", typedef.name()));

--- a/src/check/types/type_concretifier.rs
+++ b/src/check/types/type_concretifier.rs
@@ -119,6 +119,12 @@ impl<'err, 'builder, 'graph> ItemVisitor
         // they're not kept in the global scope:
         self.visit_block(block_fn.block());
     }
+
+    fn visit_type_alias_decl(&mut self, typedef: &TypeAliasDeclaration) {
+        trace!("Visiting typedef {}", typedef.name());
+        self.infer_var(&typedef.id(), typedef.token(),
+            format!("typedef {}", typedef.name()));
+    }
 }
 
 impl<'err, 'builder, 'graph> BlockVisitor

--- a/src/compile/module_compiler.rs
+++ b/src/compile/module_compiler.rs
@@ -157,7 +157,7 @@ impl<'ctx, 'b, M> ItemVisitor for ModuleCompiler<'ctx, 'b, M>
         }
     }
 
-    fn visit_type_alias_decl(&mut self, _typedef: &TypeAliasDeclaration) {
+    fn visit_typedef(&mut self, _typedef: &Typedef) {
         // skip, typedef is not compiled.
     }
 }

--- a/src/compile/module_compiler.rs
+++ b/src/compile/module_compiler.rs
@@ -156,6 +156,10 @@ impl<'ctx, 'b, M> ItemVisitor for ModuleCompiler<'ctx, 'b, M>
             self.module_provider.pass_manager().run(&fn_ref);
         }
     }
+
+    fn visit_type_alias_decl(&mut self, _typedef: &TypeAliasDeclaration) {
+        // skip, typedef is not compiled.
+    }
 }
 
 impl<'ctx, 'b, M> BlockVisitor for ModuleCompiler<'ctx, 'b, M>

--- a/src/identify/names/expr_namer.rs
+++ b/src/identify/names/expr_namer.rs
@@ -98,7 +98,7 @@ impl<'err, 'builder> ItemVisitor for ExpressionVarIdentifier<'err, 'builder> {
         // pushing handled by `visit_block`, we reset current_id on next item.
     }
 
-    fn visit_type_alias_decl(&mut self, _typedef: &TypeAliasDeclaration) {
+    fn visit_typedef(&mut self, _typedef: &Typedef) {
         // skip, only visiting expressions
     }
 }

--- a/src/identify/names/expr_namer.rs
+++ b/src/identify/names/expr_namer.rs
@@ -97,6 +97,10 @@ impl<'err, 'builder> ItemVisitor for ExpressionVarIdentifier<'err, 'builder> {
 
         // pushing handled by `visit_block`, we reset current_id on next item.
     }
+
+    fn visit_type_alias_decl(&mut self, _typedef: &TypeAliasDeclaration) {
+        // skip, only visiting expressions
+    }
 }
 
 impl<'err, 'builder> BlockVisitor for ExpressionVarIdentifier<'err, 'builder> {

--- a/src/identify/names/item_namer.rs
+++ b/src/identify/names/item_namer.rs
@@ -109,7 +109,7 @@ impl<'err, 'builder> ItemVisitor for ItemVarIdentifier<'err, 'builder> {
         self.current_id.increment();
     }
 
-    fn visit_type_alias_decl(&mut self, typedef: &TypeAliasDeclaration) {
+    fn visit_typedef(&mut self, typedef: &Typedef) {
         trace!("Visiting type alias {}", typedef.name());
         // We name type aliases in a pass before checking their contents.
         // This allows reverse lookup:

--- a/src/identify/type_scope_builder.rs
+++ b/src/identify/type_scope_builder.rs
@@ -1,6 +1,6 @@
 //!
 
-use ast::ScopedId;
+use ast::{ScopedId, Identifier};
 use identify::{ConcreteType, NamedType};
 
 use std::collections::HashMap;
@@ -54,10 +54,12 @@ impl TypeScopeBuilder {
     }
 
     /// Add a new concrete type with the given ID to the type scope.
-    ///
-    /// This is used for adding function types, which are not tracked by name
-    /// but instead by ID, as they are first identified for expressions.
     pub fn add_type(&mut self, id: ScopedId, ty: ConcreteType) {
+        self.types.insert(id, ty);
+    }
+
+    pub fn add_named_type(&mut self, name: String, id: ScopedId, ty: ConcreteType) {
+        self.names.insert(name.clone(), id.clone());
         self.types.insert(id, ty);
     }
 }

--- a/src/identify/types/expr_namer.rs
+++ b/src/identify/types/expr_namer.rs
@@ -39,7 +39,7 @@ impl<'err, 'builder> ItemVisitor for ExprTypeIdentifier<'err, 'builder> {
         self.visit_block(block_fn.block());
     }
 
-    fn visit_type_alias_decl(&mut self, _typedef: &TypeAliasDeclaration) {
+    fn visit_typedef(&mut self, _typedef: &Typedef) {
         // skip, only visiting expressions
     }
 }

--- a/src/identify/types/expr_namer.rs
+++ b/src/identify/types/expr_namer.rs
@@ -31,11 +31,16 @@ impl<'err, 'builder> UnitVisitor for ExprTypeIdentifier<'err, 'builder> {
 
 impl<'err, 'builder> ItemVisitor for ExprTypeIdentifier<'err, 'builder> {
     fn visit_block_fn_decl(&mut self, block_fn: &BlockFnDeclaration) {
+        trace!("Visiting declaration of fn {}", block_fn.name());
         if block_fn.id().is_default() {
             trace!("Skipping unidentified block fn {}", block_fn.name());
             return
         }
         self.visit_block(block_fn.block());
+    }
+
+    fn visit_type_alias_decl(&mut self, _typedef: &TypeAliasDeclaration) {
+        // skip, only visiting expressions
     }
 }
 

--- a/src/identify/types/expr_typographer.rs
+++ b/src/identify/types/expr_typographer.rs
@@ -127,7 +127,7 @@ impl<'err, 'builder, 'graph> ItemVisitor
         }
     }
 
-    fn visit_type_alias_decl(&mut self, _typedef: &TypeAliasDeclaration) {
+    fn visit_typedef(&mut self, _typedef: &Typedef) {
         // Only looking at expressions
     }
 

--- a/src/identify/types/expr_typographer.rs
+++ b/src/identify/types/expr_typographer.rs
@@ -126,6 +126,11 @@ impl<'err, 'builder, 'graph> ItemVisitor
                 InferenceSource::FnReturnType(block_fn.ident().clone()));
         }
     }
+
+    fn visit_type_alias_decl(&mut self, _typedef: &TypeAliasDeclaration) {
+        // Only looking at expressions
+    }
+
 }
 
 impl<'err, 'builder, 'graph> BlockVisitor

--- a/src/identify/types/inference_source.rs
+++ b/src/identify/types/inference_source.rs
@@ -16,6 +16,8 @@ pub enum InferenceSource {
     FnReturnType(Identifier),
     /// Inference source is the parameter of a function.
     FnParameter(Identifier),
+    /// Inference source is a typedef alias.
+    Typedef(Identifier),
     /// Inference source is the call argument of a function.
     CallArgument(Identifier),
     /// Inference source is the return type of a call.
@@ -60,6 +62,9 @@ impl fmt::Debug for InferenceSource {
             FnParameter(ref id) => f.debug_tuple("FnParam")
                                  .field(&id.name())
                                  .finish(),
+            Typedef(ref id) => f.debug_tuple("Typedef")
+                                .field(&id.name())
+                                .finish(),
             CallArgument(ref id) => f.debug_tuple("CallArg")
                                   .field(&id.name())
                                   .finish(),

--- a/src/identify/types/item_namer.rs
+++ b/src/identify/types/item_namer.rs
@@ -71,7 +71,7 @@ impl<'err, 'builder> ItemVisitor for ItemTypeIdentifier<'err, 'builder> {
         self.builder.add_type(fn_decl.id().clone(), fn_concrete);
     }
 
-    fn visit_type_alias_decl(&mut self, typedef: &TypeAliasDeclaration) {
+    fn visit_typedef(&mut self, typedef: &Typedef) {
         trace!("Visiting typedef {}", typedef.name());
         if typedef.id().is_default() {
             debug!("Skipping typedef {} with default id", typedef.name());

--- a/src/identify/types/item_typographer.rs
+++ b/src/identify/types/item_typographer.rs
@@ -108,7 +108,7 @@ impl<'builder, 'err, 'graph> ItemVisitor
         // Don't need to explicitly add the return type to the graph.
     }
 
-    fn visit_type_alias_decl(&mut self, typedef: &TypeAliasDeclaration) {
+    fn visit_typedef(&mut self, typedef: &Typedef) {
         trace!("Visiting typedef {}", typedef.name());
         if typedef.id().is_default() {
             trace!("Skipping typedef {} with default ID", typedef.name());

--- a/src/identify/types/type_identifier.rs
+++ b/src/identify/types/type_identifier.rs
@@ -12,7 +12,7 @@ use identify::TypeScopeBuilder;
 #[derive(Debug)]
 pub struct TypeIdentifier<'err, 'builder> {
     errors: &'err mut ErrorCollector,
-    /// New types cannot be defined yet.
+    /// New types cannot be defined within type expressions.
     builder: &'builder TypeScopeBuilder,
 }
 
@@ -26,12 +26,14 @@ impl<'err, 'builder> TypeIdentifier<'err, 'builder> {
 
 impl<'err, 'builder> TypeVisitor for TypeIdentifier<'err, 'builder> {
     fn visit_named_type_expr(&mut self, named_ty: &NamedTypeExpression) {
+        trace!("Identifying named type {}", named_ty.name());
         if let Some(type_id) =
             self.builder.named_type_id(named_ty.name()) {
             // Found the already defined type.
             named_ty.set_id(type_id.clone());
         }
         else {
+            debug!("Did not have type_id for named type {}", named_ty.name());
             self.errors.add_error(CheckerError::new(
                 named_ty.ident().token().clone(),
                 vec![],

--- a/src/lex/tokens.rs
+++ b/src/lex/tokens.rs
@@ -125,6 +125,7 @@ declare_tokens! {
 
         LeftParen: "("; Complete,
         RightParen: ")"; Complete,
+        // https://github.com/immington-industries/protosnirk/issues/64
         GitMergeBegin: "<<<<<<<"; Complete,
         InlineArrow: "=>"; Complete,
         Arrow: "->"; Complete,
@@ -147,6 +148,7 @@ declare_tokens! {
         If: "if",
         Else: "else",
         Fn: "fn",
+        Typedef: "typedef",
     }
     tynames {
         Int: "float",

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -430,6 +430,7 @@ impl<T: Tokenizer> Parser<T> {
         let item_prefix_map: HashMap<TokenType, Rc<PrefixParser<Item, T> + 'static>> =
         hashmap![
             Fn => Rc::new(FnDeclarationParser { }) as Rc<PrefixParser<Item, T>>,
+            Typedef => Rc::new(TypeAliasDeclarationParser { }) as Rc<PrefixParser<Item, T>>,
         ];
 
         Parser {

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -430,7 +430,7 @@ impl<T: Tokenizer> Parser<T> {
         let item_prefix_map: HashMap<TokenType, Rc<PrefixParser<Item, T> + 'static>> =
         hashmap![
             Fn => Rc::new(FnDeclarationParser { }) as Rc<PrefixParser<Item, T>>,
-            Typedef => Rc::new(TypeAliasDeclarationParser { }) as Rc<PrefixParser<Item, T>>,
+            Typedef => Rc::new(TypedefParser { }) as Rc<PrefixParser<Item, T>>,
         ];
 
         Parser {

--- a/src/parse/symbol/item/mod.rs
+++ b/src/parse/symbol/item/mod.rs
@@ -1,3 +1,5 @@
 mod function;
+mod type_alias;
 
 pub use self::function::FnDeclarationParser;
+pub use self::type_alias::TypeAliasDeclarationParser;

--- a/src/parse/symbol/item/mod.rs
+++ b/src/parse/symbol/item/mod.rs
@@ -1,5 +1,5 @@
 mod function;
-mod type_alias;
+mod typedef;
 
 pub use self::function::FnDeclarationParser;
-pub use self::type_alias::TypeAliasDeclarationParser;
+pub use self::typedef::TypedefParser;

--- a/src/parse/symbol/item/type_alias.rs
+++ b/src/parse/symbol/item/type_alias.rs
@@ -1,0 +1,32 @@
+//! Parser for type alias declarations
+
+use lex::{Token, Tokenizer, TokenType, TokenData};
+use ast::*;
+use parse::{Parser, ParseResult, ParseError};
+use parse::symbol::{PrefixParser, Precedence};
+
+/// Parses type alias declarations.
+///
+/// # Examples
+/// ```txt
+/// typedef Foo    =     float
+/// ^take   ^ident ^take ^type_expr
+/// ```
+#[derive(Debug, PartialEq, Clone)]
+pub struct TypeAliasDeclarationParser { }
+impl<T: Tokenizer> PrefixParser<Item, T> for TypeAliasDeclarationParser {
+    fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Item> {
+        debug_assert!(token.get_type() == TokenType::Typedef,
+            "Unexpected token {:?} to type alias parser", token);
+
+        let name = try!(parser.lvalue());
+
+        try!(parser.consume_type(TokenType::Equals));
+
+        let type_ = try!(parser.type_expr());
+
+        Ok(Item::TypeAliasDeclaration(TypeAliasDeclaration::new(
+            token, name, type_
+        )))
+    }
+}

--- a/src/parse/symbol/item/typedef.rs
+++ b/src/parse/symbol/item/typedef.rs
@@ -13,8 +13,8 @@ use parse::symbol::{PrefixParser, Precedence};
 /// ^take   ^ident ^take ^type_expr
 /// ```
 #[derive(Debug, PartialEq, Clone)]
-pub struct TypeAliasDeclarationParser { }
-impl<T: Tokenizer> PrefixParser<Item, T> for TypeAliasDeclarationParser {
+pub struct TypedefParser { }
+impl<T: Tokenizer> PrefixParser<Item, T> for TypedefParser {
     fn parse(&self, parser: &mut Parser<T>, token: Token) -> ParseResult<Item> {
         debug_assert!(token.get_type() == TokenType::Typedef,
             "Unexpected token {:?} to type alias parser", token);
@@ -25,7 +25,7 @@ impl<T: Tokenizer> PrefixParser<Item, T> for TypeAliasDeclarationParser {
 
         let type_ = try!(parser.type_expr());
 
-        Ok(Item::TypeAliasDeclaration(TypeAliasDeclaration::new(
+        Ok(Item::Typedef(Typedef::new(
             token, name, type_
         )))
     }

--- a/src/parse/tests.rs
+++ b/src/parse/tests.rs
@@ -186,10 +186,18 @@ fn blocksInBlocks(x: float) -> float
                 x + 1
 "#;
 
+pub const FLOAT_TYPE_ALIAS: &str =
+r#"
+typedef MyFloat = float
+
+fn foo(x: MyFloat) -> float
+    x
+"#;
+
 #[ignore]
 #[test]
 fn parse_example() {
-    let inputs = &[FACT_AND_HELPER];
+    let inputs = &[FLOAT_TYPE_ALIAS];
     ::env_logger::Builder::new()
         .parse("TRACE")
         .init();


### PR DESCRIPTION
This PR adds the `typedef` keyword for use in type alias declarations.

```snirk
typedef MyFloat = float

fn foo(x: MyFloat) -> float
    x
```

Type aliases are recognized by type inference as a type variable pointing to their rvalue. They are thus transparent once the `TypeConcretifier` has run.

Closes #61.