### PR TITLE
Add `{:p}` pointer formatting for LLVM types

### DIFF
--- a/src/llvm/basic_block.rs
+++ b/src/llvm/basic_block.rs
@@ -13,6 +13,8 @@ pub struct BasicBlock<'ctx> {
     _lt: PhantomData<&'ctx ()>
 }
 
+impl_llvm_ptr_fmt!(<'ctx> BasicBlock);
+
 impl<'ctx> BasicBlock<'ctx> {
     llvm_methods! { BasicBlock<'ctx> => LLVMBasicBlockRef }
 

--- a/src/llvm/builder.rs
+++ b/src/llvm/builder.rs
@@ -26,6 +26,8 @@ impl<'ctx> Drop for Builder<'ctx> {
     }
 }
 
+impl_llvm_ptr_fmt!(<'ctx> Builder);
+
 impl<'ctx> Builder<'ctx> {
     llvm_methods! { Builder<'ctx> => LLVMBuilderRef }
 

--- a/src/llvm/context.rs
+++ b/src/llvm/context.rs
@@ -13,6 +13,8 @@ pub struct Context {
     ptr: LLVMContextRef
 }
 
+impl_llvm_ptr_fmt!(Context);
+
 impl Drop for Context {
     fn drop(&mut self) {
         unsafe {

--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -23,6 +23,24 @@ macro_rules! llvm_methods {
     }
 }
 
+/// Implement fmt::Pointer for the wrapped LLVM value
+macro_rules! impl_llvm_ptr_fmt {
+    ($name:ident) => {
+        impl ::std::fmt::Pointer for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                write!(f, "{:p}", self.ptr)
+            }
+        }
+    };
+    (<$lt:tt> $name:ident) => {
+        impl<$lt> ::std::fmt::Pointer for $name<$lt> {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                write!(f, "{:p}", self.ptr)
+            }
+        }
+    }
+}
+
 macro_rules! llvm_passthrough {
     ($(#[$attr:meta])* pub fn $fn_name:ident( $($arg_name:ident : $arg_ty:ty),* ) => $wrapped_name:ident; $($rest:tt)*) => {
         $(#[$attr])*

--- a/src/llvm/module.rs
+++ b/src/llvm/module.rs
@@ -19,6 +19,8 @@ pub struct Module<'ctx> {
     _lt: PhantomData<&'ctx ()>
 }
 
+impl_llvm_ptr_fmt!(<'ctx> Module);
+
 impl<'ctx> Drop for Module<'ctx> {
     fn drop(&mut self) {
         unsafe {

--- a/src/llvm/pass_manager.rs
+++ b/src/llvm/pass_manager.rs
@@ -10,6 +10,8 @@ pub struct PassManager {
     ptr: LLVMPassManagerRef
 }
 
+impl_llvm_ptr_fmt!(PassManager);
+
 impl Drop for PassManager {
     fn drop(&mut self) {
         unsafe {
@@ -57,6 +59,8 @@ macro_rules! pass_methods {
 pub struct FunctionPassManager {
     ptr: LLVMPassManagerRef,
 }
+
+impl_llvm_ptr_fmt!(FunctionPassManager);
 
 impl Drop for FunctionPassManager {
     fn drop(&mut self) {

--- a/src/llvm/types.rs
+++ b/src/llvm/types.rs
@@ -19,6 +19,8 @@ pub struct Type<'ctx> {
     _lt: PhantomData<&'ctx ()>
 }
 
+impl_llvm_ptr_fmt!(<'ctx> Type);
+
 impl<'ctx> Type<'ctx> {
     llvm_methods!{ Type<'ctx> => LLVMTypeRef }
 

--- a/src/llvm/value.rs
+++ b/src/llvm/value.rs
@@ -22,6 +22,8 @@ pub struct Value<'ctx> {
     _lt: ::std::marker::PhantomData<&'ctx ()>
 }
 
+impl_llvm_ptr_fmt!(<'ctx> Value);
+
 impl<'ctx> Value<'ctx> {
     llvm_methods! { Value<'ctx> => LLVMValueRef }
 


### PR DESCRIPTION
Adds a macro for implementing the `{:p}` formatter for LLVM data, and implements it for all relevant structures.