### PR TITLE
`pipeline` module

### DIFF
--- a/src/check/collector.rs
+++ b/src/check/collector.rs
@@ -35,14 +35,8 @@ impl ErrorCollector {
         &self.lints
     }
 
-    pub fn errors_mut(&mut self) -> &mut [CheckerError] {
-        &mut self.errors
+    pub fn decompose(self)
+                -> (Vec<CheckerError>, Vec<CheckerError>, Vec<CheckerError>) {
+        (self.errors, self.warnings, self.lints)
     }
-    pub fn warnings_mut(&mut self) -> &mut [CheckerError] {
-        &mut self.warnings
-    }
-    pub fn lints_mut(&mut self) -> &mut [CheckerError] {
-        &mut self.errors
-    }
-
 }

--- a/src/check/errors.rs
+++ b/src/check/errors.rs
@@ -1,8 +1,7 @@
 //! Result types for Verification
 
-use ast::Unit;
 use lex::{Token};
-
+use ast::Unit;
 
 /// Compiler error returned by an expression verifier.
 ///

--- a/src/identify/mod.rs
+++ b/src/identify/mod.rs
@@ -44,7 +44,7 @@
 mod names;
 mod concrete_type;
 mod types;
-pub use self::types::{TypeGraph, InferenceSource};
+pub use self::types::{TypeGraph, InferenceSource, ASTTypeChecker};
 mod scope_builder;
 mod type_scope_builder;
 pub use self::scope_builder::{ScopeBuilder, NameScopeBuilder};

--- a/src/identify/types/mod.rs
+++ b/src/identify/types/mod.rs
@@ -4,7 +4,6 @@ use self::type_identifier::TypeIdentifier;
 mod item_namer;
 mod expr_namer;
 
-
 pub use self::item_namer::ItemTypeIdentifier;
 pub use self::expr_namer::ExprTypeIdentifier;
 

--- a/src/lex/tokenizer.rs
+++ b/src/lex/tokenizer.rs
@@ -49,6 +49,7 @@ enum TokenizerState {
 }
 
 /// Hacky implementation of a tokenizer.
+#[derive(Debug)]
 pub struct IterTokenizer<I> where I: Iterator<Item=char> {
     /// Keywords registered with the tokenizer
     keywords: HashSet<CowStr>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,16 +62,9 @@
 //!
 //! See `compile::ModuleCompiler`.
 //!
-//! ## `Run`
+//! ## `Pipeline`
 //!
-//! This is an in-progess interface to LLVM JIT. In the future, `const` code
-//! will be run during compilation when possible.
-//!
-//!
-//! ## `Test` (TBD)
-//!
-//! In addition to each pass supplying test harnasses and frameworks,
-//! a full-scale test library will be added to run automated tests.
+//! Orchastrate the compilation process.
 
 #![allow(dead_code, unused_imports)]
 
@@ -95,6 +88,7 @@ pub mod identify;
 pub mod check;
 pub mod lint;
 pub mod compile;
+pub mod pipeline;
 
 #[cfg(test)]
 mod tests;

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -1,0 +1,174 @@
+//! Runner for compiling projects.
+
+use lex::{Tokenizer, IterTokenizer};
+use parse::{Parser, ParseError};
+use ast::{Unit, ScopedId, visit::UnitVisitor};
+use identify::{NameScopeBuilder, TypeScopeBuilder, ASTIdentifier};
+use identify::{ASTTypeChecker, TypeGraph};
+use check::{CheckerError, ErrorCollector, TypeConcretifier, TypeMapping};
+use compile::{ModuleProvider, ModuleCompiler, SimpleModuleProvider};
+use llvm::{Context, Module, Builder, Value};
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::Path;
+use std::str::Chars;
+use std::io::{self, Read, Write};
+
+#[derive(Debug)]
+pub struct Runner<'input> {
+    iter: IterTokenizer<Chars<'input>>,
+    name: String
+}
+
+impl<'input> Runner<'input> {
+    pub fn from_string(text: &'input str, name: String) -> Runner<'input> {
+        Runner {
+            iter: IterTokenizer::new(text.chars()),
+            name
+        }
+    }
+    pub fn from_file<P: AsRef<Path>>(path: P, buffer: &'input mut String)
+                                     -> io::Result<Runner<'input>> {
+        let name = path.as_ref().to_string_lossy().into();
+        let mut file = try!(File::open(path));
+        try!(file.read_to_string(buffer));
+        Ok(Runner::from_string(buffer, name))
+    }
+
+    pub fn parse(self) -> Result<IdentifyRunner, ParseError> {
+        let mut parser = Parser::new(self.iter);
+        let unit = try!(parser.parse_unit());
+        Ok(IdentifyRunner::new(unit, self.name))
+    }
+}
+
+#[derive(Debug)]
+pub struct IdentifyRunner {
+    name: String,
+    unit: Unit,
+    errors: ErrorCollector,
+    name_builder: NameScopeBuilder,
+    type_builder: TypeScopeBuilder,
+    graph: TypeGraph
+}
+
+impl IdentifyRunner {
+    fn new(unit: Unit, name: String) -> IdentifyRunner {
+        IdentifyRunner {
+            unit, name,
+            errors: ErrorCollector::new(),
+            name_builder: NameScopeBuilder::new(),
+            type_builder: TypeScopeBuilder::with_primitives(),
+            graph: TypeGraph::with_primitives()
+        }
+    }
+
+    pub fn identify(mut self) -> Result<CheckRunner, Vec<CheckerError>> {
+        ASTIdentifier::new(&mut self.name_builder,
+                          &mut self.type_builder,
+                          &mut self.errors)
+            .visit_unit(&self.unit);
+        if !self.errors.errors().is_empty() {
+            let (errors, _warns, _lints) = self.errors.decompose();
+            Err(errors)
+        }
+        else {
+            Ok(CheckRunner::new(self))
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CheckRunner {
+    unit: Unit,
+    name: String,
+    errors: ErrorCollector,
+    name_builder: NameScopeBuilder,
+    type_builder: TypeScopeBuilder,
+    graph: TypeGraph
+}
+
+impl CheckRunner {
+    fn new(runner: IdentifyRunner) -> CheckRunner {
+        CheckRunner {
+            unit: runner.unit,
+            name: runner.name,
+            errors: runner.errors,
+            name_builder: runner.name_builder,
+            type_builder: runner.type_builder,
+            graph: runner.graph
+        }
+    }
+
+    pub fn check(mut self) -> Result<CheckedUnit, Vec<CheckerError>> {
+        let results = {
+            let mut tc = TypeConcretifier::new(&self.type_builder,
+                                               &mut self.errors,
+                                               &mut self.graph);
+            tc.visit_unit(&self.unit);
+            tc.into_results()
+        };
+        if !self.errors.errors().is_empty() {
+            let (errors, _warns, _lints) = self.errors.decompose();
+            Err(errors)
+        }
+        else {
+            Ok(CheckedUnit::new(self.unit, self.name, results))
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CheckedUnit {
+    unit: Unit,
+    name: String,
+    map: TypeMapping
+}
+impl CheckedUnit {
+    fn new(unit: Unit, name: String, map: TypeMapping) -> CheckedUnit {
+        CheckedUnit { unit, name, map }
+    }
+
+    pub fn unit(&self) -> &Unit {
+        &self.unit
+    }
+
+    pub fn type_map(&self) -> &TypeMapping {
+        &self.map
+    }
+}
+
+pub struct CompileRunner<'ctx> {
+    context: &'ctx Context
+}
+impl<'ctx> CompileRunner<'ctx> {
+    pub fn new(context: &'ctx Context) -> CompileRunner<'ctx> {
+        CompileRunner { context }
+    }
+
+    pub fn compile(&mut self, unit: CheckedUnit, optimizations: bool)
+                   -> SimpleModuleProvider<'ctx> {
+        let module = self.context.new_module(&unit.name);
+        {
+            let builder = Builder::new(&self.context);
+            let mut ir_code = Vec::new();
+            let mut scopes = HashMap::new();
+            {
+                let module_provider = SimpleModuleProvider::new(module,
+                                                                false);
+                let mut compiler = ModuleCompiler::new(unit.map,
+                    module_provider,
+                    &self.context,
+                    &builder,
+                    &mut ir_code,
+                    &mut scopes,
+                    optimizations);
+                compiler.visit_unit(&unit.unit);
+
+                let (provider, _types) = compiler.decompose();
+                provider
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds basic "runners" in the `pipeline` module. This is similar to Rust's `driver`s, objects which organize the compilation process between the passes. I expect these to change in the future.

This PR is the first step towards #47.

Closes #56.