### PR TITLE
Fix ModuleCompiler attempting to return values on void functions

### DIFF
--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -40,6 +40,11 @@ pub fn compile<'ctx>(input: &'static str,
     }
 }
 
+pub const COMPILE_EXAMPLE: &str = r#"
+fn foo(x: float, y: float) // returns void
+    x + y // statement
+"#;
+
 #[ignore]
 #[test]
 fn compile_example() {
@@ -48,8 +53,8 @@ fn compile_example() {
     {
         let context = Context::new();
         let module_provider = compile(
-                parse_tests::BLOCKS_IN_BLOCKS,
-                "FACT_HELPER",
+                COMPILE_EXAMPLE,
+                "COMPILE_EXAMPLE",
                 &context);
 
         module_provider.module().dump();


### PR DESCRIPTION
Previously, `ModuleCompiler` used some old code to attempt to always return the last expression it had visited in its `ir_code` stack. This was problematic for `fn`s which do not return a value:

```snirk
fn foo(x: float, y: float) // no return value
    x + y // statement
```

This PR fixes this issue and causes the proper `ret void` instruction to be emitted in this case.