### PR TITLE
Fix identify handing of do blocks

### DIFF
--- a/src/compile/tests.rs
+++ b/src/compile/tests.rs
@@ -41,8 +41,9 @@ pub fn compile<'ctx>(input: &'static str,
 }
 
 pub const COMPILE_EXAMPLE: &str = r#"
-fn foo(x: float, y: float) // returns void
-    x + y // statement
+fn foo() -> float
+    do
+        1
 "#;
 
 #[ignore]

--- a/src/identify/names/expr_namer.rs
+++ b/src/identify/names/expr_namer.rs
@@ -105,6 +105,7 @@ impl<'err, 'builder> ItemVisitor for ExpressionVarIdentifier<'err, 'builder> {
 
 impl<'err, 'builder> BlockVisitor for ExpressionVarIdentifier<'err, 'builder> {
     fn visit_block(&mut self, block: &Block) {
+        trace!("Visiting a block");
         // Give blocks scoped IDs in line with the current block
         block.set_id(self.current_id.clone());
 
@@ -169,7 +170,7 @@ impl<'err, 'builder> StatementVisitor
 
     fn visit_do_block(&mut self, do_block: &DoBlock) {
         trace!("Visiting do block");
-        visit::walk_block(self, do_block.block());
+        visit::walk_do_block(self, do_block);
     }
 
     fn visit_if_block(&mut self, if_block: &IfBlock) {


### PR DESCRIPTION
The `ExprVarIdentifier` had been skipping over the block data of `do` blocks and just visiting the individual statements. This PR fixes handling of `do` blocks.

Closes #75.